### PR TITLE
Quick customization

### DIFF
--- a/Autounattend-base.xml
+++ b/Autounattend-base.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DiskConfiguration>
+                <WillShowUI>OnError</WillShowUI>
+                <Disk wcm:action="add">
+                    <CreatePartitions>
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Size>100</Size>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Extend>true</Extend>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <ModifyPartition wcm:action="add">
+                            <Active>true</Active>
+                            <Label>Boot</Label>
+                            <Format>NTFS</Format>
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Format>NTFS</Format>
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                            <Label>System</Label>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                </Disk>
+            </DiskConfiguration>
+            <ImageInstall>
+                <OSImage>
+                    <InstallTo>
+                        <PartitionID>2</PartitionID>
+                        <DiskID>0</DiskID>
+                    </InstallTo>
+                    <InstallToAvailablePartition>false</InstallToAvailablePartition>
+                    <WillShowUI>OnError</WillShowUI>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <!--
+                                Windows 7 ENTERPRISE
+                                Windows 8 ENTERPRISE
+                                Windows 8 PROFESSIONAL
+                                Windows 8.1 ENTERPRISE
+                                Windows 8.1 PROFESSIONAL
+                                Windows Server 2008 R2 SERVERHYPERCORE
+                                Windows Server 2008 R2 SERVERSTANDARD
+                                Hyper-V Server 2012 SERVERHYPERCORE
+                                Windows Server 2012 SERVERSTANDARD
+                                Hyper-V Server 2012 R2 SERVERHYPERCORE
+                                Windows Server 2012 R2 SERVERSTANDARD
+                            -->
+                            <Value>Windows Server 2012 R2 SERVERSTANDARD</Value>
+                        </MetaData>
+                    </InstallFrom>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <AcceptEula>true</AcceptEula>
+                <!--
+                <ProductKey>
+                    <Key>XXXXX-XXXXX-XXXXX-XXXXX-XXXXX</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                -->
+            </UserData>
+        </component>
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <UILanguage>en-US</UILanguage>
+            <SystemLocale>en-US</SystemLocale>
+            <UserLocale>en-US</UserLocale>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <VisualEffects>
+                <FontSmoothing>ClearType</FontSmoothing>
+            </VisualEffects>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <!--
+                    ProtectYourPC:
+                    1 Specifies the recommended level of protection for your computer.
+                    2 Specifies that only updates are installed.
+                    3 Specifies that automatic protection is disabled.
+                -->
+                <ProtectYourPC>3</ProtectYourPC>
+                <NetworkLocation>Work</NetworkLocation>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <!-- Comment the following two options on Windows Vista / 7 and Windows Server 2008 / 2008 R2 -->
+                <!--
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                -->
+            </OOBE>
+            <!-- Use FirstLogonCommands instead of LogonCommands if you don't need to install Windows Updates -->
+            <LogonCommands>
+                <AsynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -File C:\Windows\Temp\Logon.ps1</CommandLine>
+                    <Order>1</Order>
+                </AsynchronousCommand>
+            </LogonCommands>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -File C:\Windows\Temp\FirstLogon.ps1</CommandLine>
+                    <Order>1</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <UserAccounts>
+                <!--
+                    Password to be used only during initial provisioning.
+                    Must be rest with final Sysprep.
+                -->
+                <AdministratorPassword>
+                    <Value>Passw0rd</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+                <!-- The following is needed on a client OS -->
+                <!--
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Description>Admin user</Description>
+                        <DisplayName>Admin</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Admin</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                -->
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>Passw0rd</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Enabled>true</Enabled>
+                <LogonCount>50</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+            <ComputerName>*</ComputerName>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <fDenyTSConnections>false</fDenyTSConnections>
+        </component>
+        <component name="Microsoft-Windows-TerminalServices-RDP-WinStationExtensions" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserAuthentication>0</UserAuthentication>
+        </component>
+        <component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirewallGroups>
+                <FirewallGroup wcm:action="add" wcm:keyValue="RemoteDesktop">
+                    <Active>true</Active>
+                    <Profile>all</Profile>
+                    <Group>@FirewallAPI.dll,-28752</Group>
+                </FirewallGroup>
+            </FirewallGroups>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="NonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <TimeZone>UTC</TimeZone>
+            <ComputerName>*</ComputerName>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>powershell -NoLogo -Command "(new-object System.Net.WebClient).DownloadFile('https://raw.github.com/cloudbase/windows-openstack-imaging-tools/master/Specialize.ps1', 'c:\Windows\Temp\Specialize.ps1')"</Path>
+                    <Description>Download Specialize script</Description>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Path>powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -File C:\Windows\Temp\Specialize.ps1</Path>
+                    <Description>Run Specialize script</Description>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+        <component name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="NonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <CEIPEnabled>0</CEIPEnabled>
+        </component>
+    </settings>
+</unattend>

--- a/Autounattend-base.xml
+++ b/Autounattend-base.xml
@@ -102,10 +102,8 @@
                 <NetworkLocation>Work</NetworkLocation>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
                 <!-- Comment the following two options on Windows Vista / 7 and Windows Server 2008 / 2008 R2 -->
-                <!--
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
                 <HideLocalAccountScreen>true</HideLocalAccountScreen>
-                -->
             </OOBE>
             <!-- Use FirstLogonCommands instead of LogonCommands if you don't need to install Windows Updates -->
             <LogonCommands>
@@ -130,7 +128,6 @@
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <!-- The following is needed on a client OS -->
-                <!--
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Description>Admin user</Description>
@@ -139,7 +136,6 @@
                         <Name>Admin</Name>
                     </LocalAccount>
                 </LocalAccounts>
-                -->
             </UserAccounts>
             <AutoLogon>
                 <Password>

--- a/README.md
+++ b/README.md
@@ -110,3 +110,21 @@ with:
 Once done, the floppy image can be easily generated on Linux with:
 
     ./create-autounattend-floppy.sh
+
+
+----------------------------------------------
+Windows XP instructions:
+edit Winnt.sif and xp-support/sysprep.inf and enter your product key
+run:
+  sudo ./create-autounattend-floppy.sh -x
+  ./create-xp-support-iso.sh
+  ./download-virtio.sh
+  ./create-xp.sh windows-xp-sp3-filename.iso
+In a new window run:
+  vncviewer :1
+When prompted:
+ * Select unpartitioned space.
+ * Select Format the partition using the NTFS file system (Quick)
+ * Whenever you see the dialog "Hardware Installation" Press "Continue Anyway"
+Once the vm shuts down, you should be able to upload the image directly to OpenStack.
+

--- a/Winnt.sif
+++ b/Winnt.sif
@@ -1,0 +1,38 @@
+;SetupMgrTag
+[Data]
+    AutoPartition=1
+    MsDosInitiated="0"
+    UnattendedInstall="Yes"
+    AutomaticUpdates=no
+
+[Unattended]
+    UnattendMode=FullUnattended
+    OemSkipEula=Yes
+    OemPreinstall=No
+    TargetPath=\WINDOWS
+    UnattendSwitch=Yes
+
+[GuiUnattended]
+    AdminPassword="foo"
+    EncryptedAdminPassword=NO
+    AutoLogon=Yes
+    AutoLogonCount=1
+    OEMSkipRegional=1
+    TimeZone=85
+    OemSkipWelcome=1
+
+[UserData]
+    ProductKey=XXXXX-XXXXX-XXXXX-XXXXX-XXXXX
+    FullName="YOUR NAME"
+    OrgName="YOUR ORG"
+    ComputerName=*
+
+[Identification]
+    JoinWorkgroup=WORKGROUP
+
+[Networking]
+    InstallDefaultComponents=Yes
+
+[GuiRunOnce]
+"f:\first.cmd"
+

--- a/create-autounattend-floppy.sh
+++ b/create-autounattend-floppy.sh
@@ -11,6 +11,27 @@ BASEDIR=$(dirname $0)
 FLOPPY_IMAGE=$BASEDIR/Autounattend.vfd
 CONTENT_SRC=$BASEDIR/Autounattend.xml
 
+while getopts ":xh" opt; do
+	case $opt in
+		x)
+			CONTENT_SRC=$BASEDIR/Winnt.sif
+      		;;
+		h)
+			echo "Usage: create-autounattend-floppy.sh [-x]"
+			echo "    -x - xp mode"
+			exit 1
+      		;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+		:)
+			echo "Option -$OPTARG requires an argument." >&2
+			exit 1
+			;;
+	esac
+done
+
 TMP_FLOPPY_IMAGE=`/bin/mktemp`
 TMP_MOUNT_PATH=`/bin/mktemp -d`
 

--- a/create-xp-support-iso.sh
+++ b/create-xp-support-iso.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+pushd xp-support
+if [ ! -f NetFx20SP1_x86.exe ]
+then
+	curl -o NetFx20SP1_x86.exe http://download.microsoft.com/download/0/8/c/08c19fa4-4c4f-4ffb-9d6c-150906578c9e/NetFx20SP1_x86.exe
+fi
+if [ ! -f WindowsXP-KB968930-x86-ENG.exe ]
+then
+	curl -o WindowsXP-KB968930-x86-ENG.exe http://download.microsoft.com/download/E/C/E/ECE99583-2003-455D-B681-68DB610B44A4/WindowsXP-KB968930-x86-ENG.exe
+fi
+popd
+mkisofs -o xp-support.iso -J xp-support

--- a/create-xp.sh
+++ b/create-xp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ISO="$1"
+
+qemu-img create -f qcow2 -o preallocation=metadata WindowsXP-tmp.qcow2 16G
+
+kvm -name instance-00000220 -M pc -cpu Westmere,+rdtscp,+pdpe1gb,+dca,+pcid,+pdcm,+xtpr,+tm2,+est,+smx,+vmx,+ds_cpl,+monitor,+dtes64,+pclmuldq,+pbe,+tm,+ht,+ss,+acpi,+ds,+vme -enable-kvm -m 4096 -smp 2,sockets=2,cores=1,threads=1 -uuid 1d6ba93c-efeb-468c-b2b9-d6325d5a24ff -smbios type=1,manufacturer="Red Hat Inc.,product=OpenStack Nova,version=2013.1.4-1.el6,serial=44454c4c-4a00-1033-8034-c8c04f595131,uuid=1d6ba93c-efeb-468c-b2b9-d6325d5a24ff" -nodefconfig -nodefaults -chardev socket,id=charmonitor,path=foo.monitor,server,nowait -mon chardev=charmonitor,id=monitor,mode=control -rtc base=utc,driftfix=slew -no-kvm-pit-reinjection -device piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2 -chardev file,id=charserial0,path=console.log -device isa-serial,chardev=charserial0,id=serial0 -chardev pty,id=charserial1 -device isa-serial,chardev=charserial1,id=serial1 -device usb-tablet,id=input0 -vnc 127.0.0.1:1 -k en-us -vga cirrus -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x5 -netdev user,id=mynet0 -device rtl8139,netdev=mynet0,bus=pci.0,addr=0x3 -drive file="$ISO",index=1,media=cdrom -drive file=virtio-win-latest.iso,index=2,media=cdrom -drive file=xp-support.iso,index=3,media=cdrom WindowsXP-tmp.qcow2 -boot d -fda Autounattend.vfd
+qemu-img convert -c -f qcow2 -O qcow2 WindowsXP-tmp.qcow2 WindowsXP.qcow2
+rm -f WindowsXP-tmp.qcow2
+

--- a/customize.sh
+++ b/customize.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+editions=('vista' '7' '8' '2008' '2012')
+client_editions=('vista' '7' '8')
+os_list_above_7=('8' '2012')
+
+edition_vista=[]
+edition_7=('Windows 7 ENTERPRISE' 'Windows 7 ENTERPRISEN')
+edition_8=('Windows 8 ENTERPRISE' 'Windows 8 PROFESSIONAL' 'Windows 8.1 ENTERPRISE' 'Windows 8.1 PROFESSIONAL')
+edition_2008=('Windows Server 2008 R2 SERVERHYPERCORE' 'Windows Server 2008 R2 SERVERSTANDARD')
+edition_2012=('Hyper-V Server 2012 SERVERHYPERCORE' 'Windows Server 2012 SERVERSTANDARD' 'Hyper-V Server 2012 R2 SERVERHYPERCORE' 'Windows Server 2012 R2 SERVERSTANDARD')
+
+bitness=64
+while getopts ":e:f:p:h" opt; do
+	case $opt in
+		e)
+			edition=$OPTARG
+      		;;
+		f)
+			full_edition=$OPTARG
+      		;;
+		p)
+			bitness=$OPTARG
+      		;;
+		h)
+			echo "Usage: customize.sh -e <edition> -f '<full edition>' [-p 64|32]"
+			exit 1
+      		;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+		:)
+			echo "Option -$OPTARG requires an argument." >&2
+			exit 1
+			;;
+	esac
+done
+
+if [ "x$edition" == "x" ]
+then
+	echo "Please specify an edition with the -e flag. Known editions:"
+	for e in "${editions[@]}"
+	do
+	    echo "    $e"
+	done
+	exit 1
+fi
+
+if [ "x$full_edition" == "x" ]
+then
+	echo "Please specify a full edition with the -f flag. Known edition strings for the selected OS:"
+	eval known_editions=( '"${edition_'${edition}'[@]}"' )
+	for e in "${known_editions[@]}"
+	do
+	    echo "    $e"
+	done
+	exit 1
+fi
+
+client_os=0
+for e in "${client_editions[@]}"
+do
+	if [ $e == $edition ]
+	then
+		client_os=1
+		break
+	fi
+done
+
+os_above_7=0
+for e in "${os_list_above_7[@]}"
+do
+	if [ $e == $edition ]
+	then
+		os_above_7=1
+		break
+	fi
+done
+
+f=Autounattend.xml
+cp Autounattend-base.xml $f
+xmlstarlet ed -L -u "/_:unattend/_:settings[@pass='windowsPE']/_:component/_:ImageInstall/_:OSImage/_:InstallFrom/_:MetaData/_:Value" -v "$full_edition" $f
+if [ $client_os -ne 1 ]
+then
+	#Remove client os flags
+	xmlstarlet ed -L -d "/_:unattend/_:settings[@pass='oobeSystem']/_:component/_:UserAccounts/_:LocalAccounts" $f
+fi
+if [ $os_above_7 -ne 1 ]
+then
+	#Remove flags that don't work with 7 and below
+	xmlstarlet ed -L -d "/_:unattend/_:settings[@pass='oobeSystem']/_:component/_:OOBE/_:HideOnlineAccountScreens" $f
+	xmlstarlet ed -L -d "/_:unattend/_:settings[@pass='oobeSystem']/_:component/_:OOBE/_:HideLocalAccountScreen" $f
+fi
+if [ "x$bitness" == 'x32' ]
+then
+	sed -i 's/processorArchitecture="amd64"/processorArchitecture="x86"/g' $f
+fi

--- a/download-virtio.sh
+++ b/download-virtio.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+BASEURL=http://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/
+ISO=`curl "$BASEURL"| grep \.iso | sed 's/.*a href="\(virtio-win-[^"]*\.iso\).*/\1/'`
+echo "$ISO" | grep -z '^virtio-win-[^"]*\.iso$' 2>/dev/null
+if [ $? -ne 0 ]
+then
+	echo Failed to find virtio version.
+fi
+if [ ! -f "$ISO" ]
+then
+	curl -o "$ISO" "$BASEURL"/"$ISO"
+fi
+rm -f virtio-win-latest.iso
+ln -s "$ISO" virtio-win-latest.iso

--- a/xp-support/SetupSysprep.ps1
+++ b/xp-support/SetupSysprep.ps1
@@ -1,0 +1,15 @@
+mkdir c:\sysprep
+mkdir c:\sysprep\i386
+mkdir c:\sysprep\i386\`$oem`$
+mkdir c:\Drivers
+mkdir c:\Drivers\virtio
+cp e:\wxp\x86\* c:\Drivers\virtio
+cp e:\xp\x86\* c:\Drivers\virtio
+$Shell = New-Object -ComObject Shell.Application
+$CabFiles = $Shell.Namespace("d:\support\tools\deploy.cab").Items()
+$DestinationFolder = $Shell.Namespace("C:\sysprep")
+$DestinationFolder.CopyHere($CabFiles)
+copy sysprep.inf c:\sysprep
+copy cmdlines.txt c:\sysprep\i386\`$oem`$
+attrib -R c:\sysprep\sysprep.inf
+attrib -R c:\sysprep\i386\`$oem`$\cmdlines.txt

--- a/xp-support/cloud-init-install.ps1
+++ b/xp-support/cloud-init-install.ps1
@@ -1,0 +1,30 @@
+$ErrorActionPreference = "Stop"
+
+try
+{
+        $Host.UI.RawUI.WindowTitle = "Downloading Cloudbase-Init..."
+
+        $CloudbaseInitMsi = "$ENV:Temp\CloudbaseInitSetup_Beta.msi"
+        $CloudbaseInitMsiUrl = "http://www.cloudbase.it/downloads/CloudbaseInitSetup_Beta.msi"
+        $CloudbaseInitMsiLog = "$ENV:Temp\CloudbaseInitSetup_Beta.log"
+
+        (new-object System.Net.WebClient).DownloadFile($CloudbaseInitMsiUrl, $CloudbaseInitMsi)
+
+        $Host.UI.RawUI.WindowTitle = "Installing Cloudbase-Init..."
+
+        $p = Start-Process -Wait -PassThru -FilePath msiexec -ArgumentList "/i $CloudbaseInitMsi /qn /l*v $CloudbaseInitMsiLog"
+        if ($p.ExitCode -ne 0)
+        {
+            throw "Installing $CloudbaseInitMsi failed. Log: $CloudbaseInitMsiLog"
+        }
+
+        $Host.UI.RawUI.WindowTitle = "Running SetSetupComplete..."
+        & "$ENV:ProgramFiles\Cloudbase Solutions\Cloudbase-Init\bin\SetSetupComplete.cmd"
+
+}
+catch
+{
+    $host.ui.WriteErrorLine($_.Exception.ToString())
+    $x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    throw
+}

--- a/xp-support/cmdlines.txt
+++ b/xp-support/cmdlines.txt
@@ -1,2 +1,2 @@
 [Commands]
-""C:\Windows\Setup\Scripts\SetupComplete.cmd""
+"C:\Windows\Setup\Scripts\SetupComplete.cmd"

--- a/xp-support/cmdlines.txt
+++ b/xp-support/cmdlines.txt
@@ -1,0 +1,2 @@
+[Commands]
+""C:\Windows\Setup\Scripts\SetupComplete.cmd""

--- a/xp-support/finish.cmd
+++ b/xp-support/finish.cmd
@@ -1,0 +1,3 @@
+c:
+cd \sysprep
+.\sysprep -quiet -pnp -mini -reseal

--- a/xp-support/first.cmd
+++ b/xp-support/first.cmd
@@ -1,0 +1,10 @@
+f:
+cd \
+start /wait NetFx20SP1_x86.exe /q 
+start /wait WindowsXP-KB968930-x86-ENG.exe /passive
+PATH=%PATH%;c:\windows\system32\windowspowershell\v1.0
+start /wait powershell -ExecutionPolicy ByPass -File SetupSysprep.ps1
+start /wait powershell -ExecutionPolicy ByPass -File cloud-init-install.ps1
+rem start /wait devmgmt.msc
+rem start f:\
+start f:\finish.cmd

--- a/xp-support/sysprep.inf
+++ b/xp-support/sysprep.inf
@@ -1,0 +1,45 @@
+;SetupMgrTag
+[Unattended]
+    ExtendOemPartition=1
+    DriverSigningPolicy=Ignore
+    OemPnPDriversPath="drivers\virtio"
+    UpdateInstalledDrivers=Yes
+    OemSkipEula=Yes
+    InstallFilesPath=C:\sysprep\i386
+
+[GuiUnattended]
+    AdminPassword=*
+    EncryptedAdminPassword=NO
+    OEMSkipRegional=1
+    TimeZone=85
+    OemSkipWelcome=1
+
+[UserData]
+    ProductKey=XXXXX-XXXXX-XXXXX-XXXXX-XXXXX
+    FullName="YOUR NAME"
+    OrgName="YOUR ORG"
+    ComputerName=*
+
+[TapiLocation]
+    CountryCode=40
+
+[RegionalSettings]
+    LanguageGroup=1
+    Language=00000409
+
+[SetupMgr]
+    DistFolder=C:\sysprep\i386
+    DistShare=windist
+
+[Identification]
+    JoinWorkgroup=WORKGROUP
+
+[Networking]
+    InstallDefaultComponents=Yes
+
+[SysPrepMassStorage]
+PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00=C:\Drivers\virtio\viostor.inf
+PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4=C:\Drivers\virtio\viostor.inf
+PCI\VEN_1AF4&DEV_1001&CC_010000=C:\Drivers\virtio\viostor.inf
+PCI\VEN_1AF4&DEV_1001&CC_0100=C:\Drivers\virtio\viostor.inf
+


### PR DESCRIPTION
Here's a patch set that does 2 things.

It provides a script that downloads the latest virtio-win drivers.

It also creates a simple script to do quick and easy customizations of the Autounattend.xml file based on setting 2 or 3 command line switches. For example:

./customize.sh -e 7 -f 'Windows 7 ENTERPRISEN' -p 32
./customize.sh -e 8 -f 'Windows 8.1 PROFESSIONAL'
./customize.sh -e 2012 -f 'Hyper-V Server 2012 R2 SERVERHYPERCORE'

It also helps you by suggesting some full image names if you do not specify one with -f and some editions if you don't specify -e.

In the future, it could be extended to take in an ISO and generate the appropriate config bits.