### PR TITLE
Excluded fauly windows update which caused the installation process to f...

### DIFF
--- a/Logon.ps1
+++ b/Logon.ps1
@@ -31,7 +31,7 @@ try
 
     $Host.UI.RawUI.WindowTitle = "Installing updates..."
 
-    Get-WUInstall -AcceptAll -IgnoreReboot -IgnoreUserInput -NotCategory "Language packs"
+    Get-WUInstall -AcceptAll -IgnoreReboot -IgnoreUserInput -NotCategory "Language packs" -NotKBArticleID "KB2975719"
     if (Get-WURebootStatus -Silent)
     {
         $Host.UI.RawUI.WindowTitle = "Updates installation finished. Rebooting."


### PR DESCRIPTION
...reeze. See http://www.infoworld.com/article/2608889/microsoft-windows/microsoft-re-releases-botched-windows-8-1-update-2-patch-kb-2975719.html and http://blogs.windows.com/bloggingwindows/2014/08/05/august-updates-for-windows-8-1-and-windows-server-2012-r2/ for details.

Change-Id: Ib0ebdafef8f3a5ac4087535b3ab160e1e52db373