### PR TITLE
Fixes Cloudbase-Init OS version

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -343,7 +343,7 @@ function New-WindowsCloudImage()
             GenerateUnattendXml $UnattendXmlPath $unattedXmlPath $image $ProductKey $AdministratorPassword
             CopyUnattendResources $resourcesDir $image.ImageInstallationType
             GenerateConfigFile $resourcesDir $installUpdates
-            DownloadCloudbaseInit $resourcesDir [string]$image.ImageArchitecture
+            DownloadCloudbaseInit $resourcesDir ([string]$image.ImageArchitecture)
             ApplyImage $winImagePath $wimFilePath $image.ImageIndex
             CreateBCDBootConfig $driveLetter
             CheckEnablePowerShellInImage $winImagePath $image


### PR DESCRIPTION
The image architecture param was not interpreted as a variable without the parenthesis.