### PR TITLE
Fixed Program Files variable and added Unblock-File to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Supports both x64 and x86 images.
 Requirements:
 
 * A host or VM running Windows 
-* Clone this repository
+* Clone this repository and unblock its files (this is really important, otherwise the generated image won't work!):
+https://technet.microsoft.com/en-us/library/hh849924.aspx
 * A Windows installation ISO or DVD, that needs to be either mounted or extracted (e.g. with 7-zip)
 * For KVM, download the VirtIO tools ISO, e.g. from: http://alt.fedoraproject.org/pub/alt/virtio-win/stable/
 
@@ -44,7 +45,7 @@ Example PowerShell script:
     $image
 
     # The product key is optional
-    #$productKey = “xxxxx-xxxxx…"
+    #$productKey = "xxxxx-xxxxx"
 
     # Add -InstallUpdates for the Windows updates (it takes longer and requires
     # more space but it's highly recommended)

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -43,16 +43,7 @@ try
     if(!$needsReboot)
     {
         $Host.UI.RawUI.WindowTitle = "Installing Cloudbase-Init..."
-
-        $osArch = (Get-WmiObject  Win32_OperatingSystem).OSArchitecture
-        if($osArch -eq "64-bit")
-        {
-            $programFilesDir = ${ENV:ProgramFiles(x86)}
-        }
-        else
-        {
-            $programFilesDir = $ENV:ProgramFiles
-        }
+        $programFilesDir = $ENV:ProgramFiles
 
         $CloudbaseInitMsiPath = "$resourcesDir\CloudbaseInit.msi"
         $CloudbaseInitMsiLog = "$resourcesDir\CloudbaseInit.log"


### PR DESCRIPTION
-The $programFilesDir variable needs to be "Program Files" always, not "Program Files (x86)" on 64-bit systems, because Cloudbase-Init has a 64-bit version already
-Change the README to address this issue https://github.com/cloudbase/windows-openstack-imaging-tools/issues/26 (added the reference to Unblock-File)