### PR TITLE
Fixed imports for curtin 0.1-bzr276

### DIFF
--- a/UnattendResources/curtin/finalize
+++ b/UnattendResources/curtin/finalize
@@ -9,6 +9,11 @@ import platform
 from curtin.log import LOG
 from curtin import util
 
+#newer curtin builds have a separate file for load_command_config
+#using hasattr because then no parameters need to be given to load_command_config to check its existence
+if not hasattr(util, "load_command_config"):
+  from curtin import config as c
+
 CLOUDBASE_INIT_TEMPLATE = """
 metadata_services=cloudbaseinit.metadata.services.maasservice.MaaSHttpService
 maas_metadata_url={url}
@@ -64,7 +69,12 @@ def get_cloudbaseinit_dir(target):
 
 def curthooks():
     state = util.load_command_environment()
-    config = util.load_command_config({}, state)
+    #newer curtin builds have a separate file for load_command_config
+    try:
+       config = util.load_command_config({}, state)
+    except AttributeError:
+       config = c.load_command_config({}, state)
+
     target = state['target']
     cloudbaseinit = get_cloudbaseinit_dir(target)
 


### PR DESCRIPTION
Newer curtin versions (at least bzr276) put the load_command_config function in a different file. The attached patch fixes that (while keeping compatibility with the older structure)