### PR TITLE
Refresh PowerShell list of active drives

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -385,6 +385,10 @@ function Add-VirtIODriversFromISO($vhdDriveLetter, $image, $isoPath) {
             $driversBasePath = ((Get-DiskImage -DevicePath $devicePath `
                 | Get-Volume).DriveLetter) + ":"
             Write-Host "Adding drivers from $driversBasePath"
+            # We call Get-PSDrive to refresh the list of active drives.
+            # Otherwise, "Test-Path $driversBasePath" will return $False
+            # http://www.vistax64.com/powershell/2653-powershell-does-not-update-subst-mapped-drives.html
+            Get-PSDrive | Out-Null
             Add-VirtIODrivers $vhdDriveLetter $image $driversBasePath
         } else {
             throw "The $isoPath is not a valid iso path."


### PR DESCRIPTION
With the old code, the virtio iso is mounted succesfully and the drive
letter is for example, D. But if we execute the powershell cmd
"Test-Path D:\", it returns "False". This issue is soved by calling
"Get-PSDrive" to refresh the active drives.