### PR TITLE
Do not use bcdboot /f for Win7 and Win2008r2

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -23,6 +23,39 @@ Please make sure you boot this image at least once before you use it.
 
 Import-Module dism
 
+function ExecRetry($command, $maxRetryCount=4, $retryInterval=4)
+{
+    $currErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+  
+    $retryCount = 0
+    while ($true)
+    {
+        try 
+        {
+            $res = Invoke-Command -ScriptBlock $command
+            $ErrorActionPreference = $currErrorActionPreference
+            return $res
+        }
+          catch [System.Exception]
+        {
+            $retryCount++
+            if ($retryCount -ge $maxRetryCount)
+            {
+                $ErrorActionPreference = $currErrorActionPreference
+                throw
+            }
+            else
+            {
+                if($_) {
+                Write-Warning $_ 
+                }
+                Start-Sleep $retryInterval
+            }
+        }
+    }
+} 
+
 function CheckIsAdmin()
 {
     $wid = [System.Security.Principal.WindowsIdentity]::GetCurrent()
@@ -204,8 +237,10 @@ function CheckDismVersionForImage($image)
 function Convert-VirtualDisk($vhdPath, $outPath, $format)
 {
     Write-Output "Converting virtual disk image from $vhdPath to $outPath..."
-    & $scriptPath\bin\qemu-img.exe convert -O $format.ToLower() $vhdPath $outPath
-    if($LASTEXITCODE) { throw "qemu-img failed to convert the virtual disk" }
+    ExecRetry {
+        & $scriptPath\bin\qemu-img.exe convert -O $format.ToLower() $vhdPath $outPath
+        if($LASTEXITCODE) { throw "qemu-img failed to convert the virtual disk" }
+    }
 }
 
 function CopyUnattendResources
@@ -256,7 +291,9 @@ function DownloadCloudbaseInit($resourcesDir, $osArch)
     $CloudbaseInitMsiPath = "$resourcesDir\CloudbaseInit.msi"
     $CloudbaseInitMsiUrl = "https://www.cloudbase.it/downloads/$CloudbaseInitMsi"
 
-    (new-object System.Net.WebClient).DownloadFile($CloudbaseInitMsiUrl, $CloudbaseInitMsiPath)
+    ExecRetry {
+        (New-Object System.Net.WebClient).DownloadFile($CloudbaseInitMsiUrl, $CloudbaseInitMsiPath)
+    }
 }
 
 function GenerateConfigFile
@@ -299,8 +336,10 @@ function EnableFeaturesInImage($winImagePath, $featureNames)
         }
 
         # Prefer Dism over Enable-WindowsOptionalFeature due to better error reporting
-        Invoke-Expression $featuresCmdStr
-        if ($LASTEXITCODE) { throw "Dism failed to enable features: $featureNames" }
+        ExecRetry {
+            Invoke-Expression $featuresCmdStr
+            if ($LASTEXITCODE) { throw "Dism failed to enable features: $featureNames" }
+        }
     }
 }
 


### PR DESCRIPTION
This pull request has 2 commits:
- Fix for BCDBoot when creating Win7 and Win2008r2 images
- Addition of ExecRetry function for preventing transient errors