### PR TITLE
Restore config file generation killed by 478e478

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -482,10 +482,10 @@ function New-WindowsCloudImage()
 
             GenerateUnattendXml $UnattendXmlPath $unattedXmlPath $image $ProductKey $AdministratorPassword
             CopyUnattendResources $resourcesDir $image.ImageInstallationType
-            CreateBCDBootConfig $drives[0] $drives[1] $DiskLayout $image
+            GenerateConfigFile $resourcesDir $installUpdates
             DownloadCloudbaseInit $resourcesDir ([string]$image.ImageArchitecture)
             ApplyImage $winImagePath $wimFilePath $image.ImageIndex
-            CreateBCDBootConfig $drives[0] $drives[1] $DiskLayout
+            CreateBCDBootConfig $drives[0] $drives[1] $DiskLayout $image
             CheckEnablePowerShellInImage $winImagePath $image
 
             # Product key is applied by the unattend.xml


### PR DESCRIPTION
Hi, 
it seems that commit 478e478 drops code regarding config file generation and updates.
