### PR TITLE
Make dism clean redundant on win2016

### DIFF
--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -206,7 +206,9 @@ try
         Install-WindowsUpdates
     }
 
-    Clean-WindowsUpdates -PurgeUpdates $purgeUpdates
+    ExecRetry {
+        Clean-WindowsUpdates -PurgeUpdates $purgeUpdates
+    }
 
     $Host.UI.RawUI.WindowTitle = "Installing Cloudbase-Init..."
 


### PR DESCRIPTION
Dism clean fails the first time is run on win2016, so we need a retry for its run