### PR TITLE
Use DISM from the ISO to improve host and target compatibility

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -163,14 +163,38 @@ function Apply-Image {
         [parameter(Mandatory=$true)]
         [string]$wimFilePath,
         [parameter(Mandatory=$true)]
-        [int]$imageIndex
+        [int]$imageIndex,
+        [Parameter(Mandatory=$true)]
+        [object]$image
     )
     Write-Output ('Applying Windows image "{0}" in "{1}"' -f $wimFilePath, $winImagePath)
     #Expand-WindowsImage -ImagePath $wimFilePath -Index $imageIndex -ApplyPath $winImagePath
     # Use Dism in place of the PowerShell equivalent for better progress update
     # and for ease of interruption with CTRL+C
-    & Dism.exe /apply-image /imagefile:${wimFilePath} /index:${imageIndex} /ApplyDir:${winImagePath}
+    $dismPath = Get-DismPath $wimFilePath $image 
+    & $dismPath /apply-image /imagefile:${wimFilePath} /index:${imageIndex} /ApplyDir:${winImagePath}
     if ($LASTEXITCODE) { throw "Dism apply-image failed" }
+}
+
+function Get-DismPath {
+    Param (
+    [parameter(Mandatory=$true)]
+    [string]$wimFilePath,
+    [Parameter(Mandatory=$true)]
+    [object]$image
+    )
+    # $defaultDism represents the host DISM path
+    $defaultDism= "$env:windir\system32\Dism.exe"
+    $driveLetter = [System.IO.Path]::GetPathRoot($WimFilePath)
+    # $imageDism represents the ISO DISM path
+    $imageDism = Join-Path $driveLetter "sources\dism.exe"
+    if ((Check-DismVersionForImage $image) -eq $false -and (Test-Path $imageDism)) {
+        Write-Host "DISM path used: $imageDism"
+        return $imageDism
+    } else { 
+        Write-Host "DISM path used: $defaultDism"
+        return $defaultDism
+    }
 }
 
 function Create-BCDBootConfig {
@@ -291,8 +315,11 @@ function Check-DismVersionForImage {
     )
     $dismVersion = New-Object System.Version `
         (Get-Command dism.exe).FileVersionInfo.ProductVersion
-    if ($image.ImageVersion.CompareTo($dismVersion) -gt 0) {
-        Write-Warning "The installed version of DISM is older than the Windows image"
+    if ($image.ImageVersion.CompareTo($dismVersion) -ne 0) {
+        Write-Warning "The installed version of DISM is different than the Windows image's"
+        return $false
+    } else {
+        return $true
     }
 }
 
@@ -389,10 +416,15 @@ function Add-DriversToImage {
         [Parameter(Mandatory=$true)]
         [string]$winImagePath,
         [Parameter(Mandatory=$true)]
-        [string]$driversPath
+        [string]$driversPath,
+        [parameter(Mandatory=$true)]
+        [string]$wimFilePath,
+        [Parameter(Mandatory=$true)]
+        [object]$image
     )
     Write-Output ('Adding drivers from "{0}" to image "{1}"' -f $driversPath, $winImagePath)
-    & Dism.exe /image:${winImagePath} /Add-Driver /driver:${driversPath} /ForceUnsigned /recurse
+    $dismPath = Get-DismPath $wimFilePath $image
+    & $dismPath /image:${winImagePath} /Add-Driver /driver:${driversPath} /ForceUnsigned /recurse
     if ($LASTEXITCODE) {
         throw "Dism failed to add drivers from: $driversPath"
     }
@@ -520,7 +552,7 @@ function Add-VirtIODrivers {
     }
     $virtioDir = "{0}\{1}\{2}" -f $driversBasePath, $virtioVer, $image.ImageArchitecture
     if (Test-Path $virtioDir) {
-        Add-DriversToImage $vhdDriveLetter $virtioDir
+        Add-DriversToImage $vhdDriveLetter $virtioDriversPath $wimFilePath $image
         return
     }
 
@@ -531,7 +563,7 @@ function Add-VirtIODrivers {
         -Architecture $image.ImageArchitecture
     foreach ($virtioDriversPath in $virtioDriversPaths) {
         if (Test-Path $virtioDriversPath) {
-            Add-DriversToImage $vhdDriveLetter $virtioDriversPath
+            Add-DriversToImage $vhdDriveLetter $virtioDriversPath $wimFilePath $image
         }
     }
 }
@@ -1074,7 +1106,7 @@ function New-WindowsCloudImage {
             Copy-UnattendResources $resourcesDir $image.ImageInstallationType $InstallMaaSHooks
             Generate-ConfigFile $resourcesDir $configValues
             Download-CloudbaseInit $resourcesDir ([string]$image.ImageArchitecture)
-            Apply-Image $winImagePath $wimFilePath $image.ImageIndex
+            Apply-Image $winImagePath $wimFilePath $image.ImageIndex $image
             Create-BCDBootConfig $drives[0] $drives[1] $DiskLayout $image
             Check-EnablePowerShellInImage $winImagePath $image
 


### PR DESCRIPTION
For example if we have a windows 2012r2 host and a 2016 target, we need to use the DISM version from the image for better compatibility