### PR TITLE
[WIP]Added feature to generate and use golden images

### DIFF
--- a/Examples/create-windows-from-golden-image.ps1
+++ b/Examples/create-windows-from-golden-image.ps1
@@ -1,0 +1,40 @@
+# Copyright 2016 Cloudbase Solutions Srl
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+$ErrorActionPreference = "Stop"
+
+git submodule update --init
+Import-Module ..\WinImageBuilder.psm1
+
+# The Windows image file path that will be generated
+$WindowsImageTargetPath = "C:\images\my-windows-image.raw.tgz"
+
+# The VHDX file path is the golden image already generated
+$WindowsImageVHDXPath = "D:\Golden\golden_image.vhdx"
+
+# Extra drivers path contains the drivers for the baremetal nodes
+# Examples: Chelsio NIC Drivers, Mellanox NIC drivers, LSI SAS drivers, etc.
+# The cmdlet will recursively install all the drivers from the folder and subfolders
+$extraDriversPath = "C:\drivers\"
+
+# Make sure the switch exists and it allows Internet access if updates
+# are to be installed
+$switchName = 'external'
+
+# This scripts generates a raw tar.gz-ed image file, that can be used with MAAS
+New-WindowsFromGoldenImage -WindowsImageVHDXPath $WindowsImageVHDXPath `
+-WindowsImageTargetPath $WindowsImageTargetPath -SizeBytes 30GB -CpuCores 4 `
+-Memory 4GB -SwitchName $switchName -PurgeUpdates:$true -DisableSwap:$true `
+-InstallUpdates:$true -$ExtraFeatures = @() -Type 'MAAS' `
+-ExtraDriversPath $extraDriversPath

--- a/Examples/create-windows-golden-image.ps1
+++ b/Examples/create-windows-golden-image.ps1
@@ -1,0 +1,54 @@
+# Copyright 2016 Cloudbase Solutions Srl
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+$ErrorActionPreference = "Stop"
+
+git submodule update --init
+Import-Module ..\WinImageBuilder.psm1
+
+# The Windows image file path that will be generated
+$windowsImagePath = "C:\images\golden-image.vhdx"
+
+# The wim file path is the installation image on the Windows ISO
+$wimFilePath = "D:\Sources\install.wim"
+
+# VirtIO ISO contains all the synthetic drivers for the KVM hypervisor
+$VirtIOISOPath = "C:\images\virtio.iso"
+$virtIODownloadLink = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.126-2/virtio-win.iso"
+
+# Download the VirtIO drivers ISO from Fedora
+(New-Object System.Net.WebClient).DownloadFile($virtIODownloadLink, $VirtIOISOPath)
+
+# Extra drivers path contains the drivers for the baremetal nodes
+# Examples: Chelsio NIC Drivers, Mellanox NIC drivers, LSI SAS drivers, etc.
+# The cmdlet will recursively install all the drivers from the folder and subfolders
+$extraDriversPath = "C:\drivers\"
+
+# Every Windows ISO can contain multiple Windows flavors like Core, Standard, Datacenter
+# Usually, the second image version is the Standard one
+$image = (Get-WimFileImagesInfo -WimFilePath $wimFilePath)[1]
+
+# Make sure the switch exists and it allows Internet access if updates
+# are to be installed
+$switchName = 'external'
+
+# This scripts generates a raw tar.gz-ed image file, that can be used with MAAS
+New-WindowsOnlineImage -WimFilePath $wimFilePath -ImageName $image.ImageName `
+    -WindowsImagePath $windowsImagePath -Type 'HYER-V' -ExtraFeatures @() `
+    -SizeBytes 30GB -CpuCores 4 -Memory 4GB -SwitchName $switchName `
+    -ProductKey $productKey -DiskLayout 'BIOS' -VirtioISOPath $virtIOISOPath `
+    -ExtraDriversPath $extraDriversPath `
+    -InstallUpdates:$true -AdministratorPassword 'Pa$$w0rd' `
+    -PurgeUpdates:$true -DisableSwap:$true -GoldImage:$true
+

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -200,6 +200,7 @@ try
     $persistDrivers = Get-IniFileValue -Path $configIniPath -Section "DEFAULT" -Key "PersistDriverInstall" -Default $true -AsBoolean
     $purgeUpdates = Get-IniFileValue -Path $configIniPath -Section "DEFAULT" -Key "PurgeUpdates" -Default $false -AsBoolean
     $disableSwap = Get-IniFileValue -Path $configIniPath -Section "DEFAULT" -Key "DisableSwap" -Default $false -AsBoolean
+    $goldImage = Get-IniFileValue -Path $configIniPath -Section "DEFAULT" -Key "GoldImage" -Default $false -AsBoolean
 
     if($installUpdates)
     {
@@ -209,6 +210,13 @@ try
     ExecRetry {
         Clean-WindowsUpdates -PurgeUpdates $purgeUpdates
     }
+
+    if ($goldImage) {
+        # Cleanup
+        Remove-Item -Recurse -Force $resourcesDir
+        Remove-Item -Force "$ENV:SystemDrive\Unattend.xml"
+        shutdown -s -t 0 -f
+     }
 
     $Host.UI.RawUI.WindowTitle = "Installing Cloudbase-Init..."
 

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1161,9 +1161,9 @@ function New-WindowsFromGoldenImage {
 
             $driveLetterGold = ((Get-DiskImage -ImagePath $WindowsImageVHDXPath | Get-Disk | Get-Partition | Get-Volume).DriveLetter + ":")
 
-            Execute-Retry {
-                Resize-Partition -DriveLetter $driveLetter -Size ($SizeBytes - 500MB) -ErrorAction Stop
-            }
+            $driveNumber = (Get-DiskImage -ImagePath $WindowsImageVHDXPath | Get-Disk).Number
+            $maxPartitionSize = (Get-PartitionSupportedSize -DiskNumber $driveNumber -PartitionNumber 1).SizeMax
+            Resize-Partition -DiskNumber $driveNumber -PartitioNumber 1 -Size $maxPartitionSize
 
             if ($ExtraDriversPath) {
                 Dism /Image:$driveLetterGold /Add-Driver /Driver:$ExtraDriversPath /ForceUnsigned /Recurse


### PR DESCRIPTION
This commit adds the posibility to generate and use golden images.

The major benefit of golden images is that it already has done
time-consuming tasks (such as installing updates and cleaning updates
files). The images are in VHDX format. Warning: The golden images are
not deployment ready because they aren't sysprepped.

In order the use them, the New-WindowsFromGoldenImage function must be
used. More details can be found in the Examples and function synopsys.

Signed-off-by: Costin Galan <cgalan@cloudbasesolutions.com>