### PR TITLE
Add skeleton for config file

### DIFF
--- a/Examples/config.ini
+++ b/Examples/config.ini
@@ -1,0 +1,30 @@
+[DEFAULT]
+wim_file_path = "D:\sources\install.wim"
+virtual_disk_path = "C:\images\my-image.vhdx"
+image_name = "Windows Server 2012 R2"
+product_key = "xxxx-xxxx-xxxx-xxxx"
+target_disk_format = "VHDX"
+type = "MAAS"
+disk_layout = "BIOS"
+image_size = "minimum"
+extra_features = "hyper-v"
+
+[drivers]
+virtio_iso_path = "C:\virtio.iso"
+drivers_path = "C:\windows-drivers"
+
+[vm]
+administrator_password = "Passw0rd"
+external_switch = "external "
+cpu_count = 2
+ram_size = 1024
+disk_size = "40G"
+
+[updates]
+install_updates = true
+purge_updates = false
+
+[sysprep]
+sysprep = true
+disable_swap = true
+persist_drivers_install = true

--- a/Examples/config.ini
+++ b/Examples/config.ini
@@ -1,30 +1,35 @@
 [DEFAULT]
 wim_file_path = "D:\sources\install.wim"
-virtual_disk_path = "C:\images\my-image.vhdx"
-image_name = "Windows Server 2012 R2"
-product_key = "xxxx-xxxx-xxxx-xxxx"
-target_disk_format = "VHDX"
+image_name = ""
+image_path = ""
+virtual_disk_format = "VHDX"
 type = "MAAS"
 disk_layout = "BIOS"
-image_size = "minimum"
-extra_features = "hyper-v"
-
-[drivers]
-virtio_iso_path = "C:\virtio.iso"
-drivers_path = "C:\windows-drivers"
+product_key = ""
+extra_features = ""
+force = false
+install_maas_hooks = false
 
 [vm]
-administrator_password = "Passw0rd"
-external_switch = "external "
-cpu_count = 2
-ram_size = 1024
+administrator_password = "Pa$$w0rd"
+external_switch = ""
+cpu_count = 1
+ram_size = 2048
 disk_size = "40G"
 
+[drivers]
+virtio_iso_path = ""
+virtio_base_path = ""
+
+drivers_path = ""
+
+
 [updates]
-install_updates = true
+install_updates = false
 purge_updates = false
 
 [sysprep]
-sysprep = true
-disable_swap = true
+run_sysprep = true
+unattend_xml_path = UnattendTemplate.xml
+disable_swap = false
 persist_drivers_install = true


### PR DESCRIPTION
As the image generation becomes more and more complex,
a config file is more suitable for generating a windows
image because it can accomodate more options at no expense for
code complexity.