### PR TITLE
Adding golden image support

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -55,6 +55,9 @@ function Get-availableConfigOptionOptions {
                            a password protected zip archive with the image will be created."},
         @{"Name" = "gold_image"; "DefaultValue" = $false; "AsBoolean" = $true;
           "Description" = "It will stop the image generation after the updates are installed and cleaned."},
+        @{"Name" = "gold_image_path";
+          "Description" = "This is the full path of the already generated golden image.
+                           It should be a valid VHDX path."},
         @{"Name" = "administrator_password"; "GroupName" = "vm"; "DefaultValue" = "Pa`$`$w0rd";
           "Description" = "This will be the Administrator user's, so that AutoLogin can be performed on the instance,
                            in order to install the required products,


### PR DESCRIPTION
This pull request adds the ability to generate golden image and start to generate an image from a golden one.

- A **golden image** is not ready to be used in a cloud. It can be used as a starting point to generate a fully working one. The major benefits it adds are that it has updates installed and the extra files cleaned. It this way, the major time consuming tasks are already done.

- When we are starting from a golden image, we just install cloudbase-init and do the cleanup process.