### PR TITLE
Added the possibility to generate golden images

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -53,6 +53,8 @@ function Get-availableConfigOptionOptions {
         @{"Name" = "zip_password";
           "Description" = "If this parameter is set, after the image is generated,
                            a password protected zip archive with the image will be created."},
+        @{"Name" = "gold_image"; "DefaultValue" = $false; "AsBoolean" = $true;
+          "Description" = "It will stop the image generation after the updates are installed and cleaned."},
         @{"Name" = "administrator_password"; "GroupName" = "vm"; "DefaultValue" = "Pa`$`$w0rd";
           "Description" = "This will be the Administrator user's, so that AutoLogin can be performed on the instance,
                            in order to install the required products,

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -189,6 +189,7 @@ try
     $persistDrivers = Get-IniFileValue -Path $configIniPath -Section "sysprep" -Key "persist_drivers_install" -Default $true -AsBoolean
     $purgeUpdates = Get-IniFileValue -Path $configIniPath -Section "updates" -Key "purge_updates" -Default $false -AsBoolean
     $disableSwap = Get-IniFileValue -Path $configIniPath -Section "sysprep" -Key "disable_swap" -Default $false -AsBoolean
+    $goldImage = Get-IniFileValue -Path $configIniPath -Section "DEFAULT" -Key "gold_image" -Default $false -AsBoolean
 
     if ($installUpdates) {
         Install-WindowsUpdates
@@ -196,6 +197,12 @@ try
 
     ExecRetry {
         Clean-WindowsUpdates -PurgeUpdates $purgeUpdates
+    }
+
+    if ($goldImage) {
+        # Cleanup and shutting down the instance
+        Remove-Item -Recurse -Force $resourcesDir
+        shutdown -s -t 0 -f
     }
 
     $Host.UI.RawUI.WindowTitle = "Installing Cloudbase-Init..."


### PR DESCRIPTION
This commit adds the option to generate golden images, which are
cloud images where the long operations are already done (installing
updates and cleaning the extra files).

Note: This image is not ready to be used in a cloud. This image can
be used as a starting point to generate a fully working image.

Signed-off-by: Costin Galan <cgalan@cloudbasesolutions.com>