### PR TITLE
Fixed Windows 7 x86 image generation

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -383,10 +383,10 @@ function Download-CloudbaseInit {
         [switch]$BetaRelease
     )
     Write-Host "Downloading Cloudbase-Init..."
-
     $msiBuildArchMap = @{
         "amd64" = "x64"
         "i386" = "x86"
+        "x86" = "x86"
     }
     $msiBuildSuffix = ""
     if (-not $BetaRelease) {


### PR DESCRIPTION
The image architecture on Windows 7 is "x86" and not 'i386'