### PR TITLE
Fixed Windows 10 Creators Update generation

### DIFF
--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -71,7 +71,7 @@ function Clean-UpdateResources {
     $HOST.UI.RawUI.WindowTitle = "Running update resources cleanup"
     # We're done, disable AutoLogon
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -Name Unattend*
-    Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AutoLogonCount
+    Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AutoLogonCount -ErrorAction SilentlyContinue
 
     # Cleanup
     Remove-Item -Recurse -Force $resourcesDir


### PR DESCRIPTION
On Windows 10 v1703, there is no AutoLogonCount regkey and the whole
generation fails. We can continue without any issues if that registry
cannot be removed/deleted because it does not exist.