### PR TITLE
Fixed image path when creating non-hyperv images

### DIFF
--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -97,6 +97,7 @@ Describe "Test New-WindowsCloudImage" {
         }
     Mock Generate-UnattendXml -Verifiable -ModuleName $moduleName { return 0 }
     Mock Copy-UnattendResources -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Copy-CustomResources -Verifiable -ModuleName $moduleName { return 0 }
     Mock Copy-Item -Verifiable -ModuleName $moduleName { return 0 }
     Mock Download-CloudbaseInit -Verifiable -ModuleName $moduleName { return 0 }
     Mock Apply-Image -Verifiable -ModuleName $moduleName { return 0 }
@@ -104,6 +105,9 @@ Describe "Test New-WindowsCloudImage" {
     Mock Check-EnablePowerShellInImage -Verifiable -ModuleName $moduleName { return 0 }
     Mock Set-WindowsWallpaper -Verifiable -ModuleName $moduleName { return 0 }
     Mock Enable-FeaturesInImage -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Get-PathWithoutExtension -Verifiable -ModuleName $moduleName { return "test" }
+    Mock Move-Item -Verifiable -ModuleName $moduleName { return 0 }
+
 
     It "Should create a windows image" {
         New-WindowsCloudImage -ConfigFilePath $fakeConfigPath | Should Be 0

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1049,6 +1049,12 @@ function New-WindowsOnlineImage {
         throw "CpuCores larger then available (logical) CPU cores."
     }
 
+    if (Test-Path $windowsImageConfig.image_path) {
+        Write-Host "Found already existing image file. Removing it..." -ForegroundColor Yellow
+        Remove-Item -Force $windowsImageConfig.image_path
+        Write-Host "Already existent image file has been removed." -ForegroundColor Yellow
+    }
+
     try {
         $barePath = Get-PathWithoutExtension $windowsImageConfig.image_path
         $virtualDiskPath = $barePath + ".vhdx"
@@ -1100,7 +1106,7 @@ function New-WindowsOnlineImage {
     } catch {
         Write-host $_
         if ($windowsImageConfig.image_path -and (Test-Path $windowsImageConfig.image_path)) {
-            Remove-Item -Force ${windowsImageConfig.image_path} -ErrorAction SilentlyContinue
+            Remove-Item -Force $windowsImageConfig.image_path -ErrorAction SilentlyContinue
         }
         Throw
     }
@@ -1142,14 +1148,14 @@ function New-WindowsCloudImage {
     Check-DismVersionForImage $image
 
     if (Test-Path $windowsImageConfig.image_path) {
+        Write-Host "Found already existing image file. Removing it..." -ForegroundColor Yellow
         Remove-Item -Force $windowsImageConfig.image_path
+        Write-Host "Already existent image file has been removed." -ForegroundColor Yellow
     }
 
-    if ($windowsImageConfig.virtual_disk_format -in @("VHD", "VHDX")) {
-        $vhdPath = $windowsImageConfig.image_path
-    } else {
-        $vhdPath = "{0}.vhd" -f (Get-PathWithoutExtension $windowsImageConfig.image_path)
-        if (Test-Path $vhdPath) { Remove-Item -Force $vhdPath }
+    $vhdPath = "{0}.vhdx" -f (Get-PathWithoutExtension $windowsImageConfig.image_path)
+    if (Test-Path $vhdPath) {
+        Remove-Item -Force $vhdPath
     }
 
     try {
@@ -1195,12 +1201,17 @@ function New-WindowsCloudImage {
         }
     }
 
-    if ($vhdPath -ne $windowsImageConfig.image_path) {
-        Convert-VirtualDisk $vhdPath $windowsImageConfig.image_path $windowsImageConfig.virtual_disk_format
-        if ($windowsImageConfig.zip_password) {
-            New-ProtectedZip -ZipPassword $windowsImageConfig.zip_password -virtualDiskPath $windowsImageConfig.image_path
-        }
+    if (!($windowsImageConfig.virtual_disk_format -in @("VHD", "VHDX"))) {
+        Convert-VirtualDisk $vhdPath $windowsImageConfig.image_path `
+            $windowsImageConfig.virtual_disk_format
         Remove-Item -Force $vhdPath
+    } elseif ($vhdPath -ne $windowsImageConfig.image_path) {
+        Move-Item -Force $vhdPath $windowsImageConfig.image_path
+    }
+
+    if ($windowsImageConfig.zip_password) {
+        New-ProtectedZip -ZipPassword $windowsImageConfig.zip_password `
+            -virtualDiskPath $windowsImageConfig.image_path
     }
     Write-Host ("Image generation finished at: {0}" -f @(Get-Date))
 }


### PR DESCRIPTION
As a VHD cannot be created without specifing a path
with vhd/vhdx extension, the image_path must be, before
the backing VHD is created, converted to have a VHD(X) suffix.