### PR TITLE
Update VirtIO drivers download path to stable

### DIFF
--- a/Examples/create-windows-online-cloud-image.ps1
+++ b/Examples/create-windows-online-cloud-image.ps1
@@ -26,7 +26,7 @@ $wimFilePath = "D:\Sources\install.wim"
 # VirtIO ISO contains all the synthetic drivers for the KVM hypervisor
 $VirtIOISOPath = "C:\images\virtio.iso"
 # Note(avladu): Do not use stable 0.1.126 version because of this bug https://github.com/crobinso/virtio-win-pkg-scripts/issues/10
-$virtIODownloadLink = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.133-2/virtio-win.iso"
+$virtIODownloadLink = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso"
 
 # Download the VirtIO drivers ISO from Fedora
 (New-Object System.Net.WebClient).DownloadFile($virtIODownloadLink, $VirtIOISOPath)


### PR DESCRIPTION
No need to change the link anymore as it will always point automatically to the latest stable version