### PR TITLE
Fixed ini.psmi use of relative paths

### DIFF
--- a/Examples/create-windows-cloud-image.ps1
+++ b/Examples/create-windows-cloud-image.ps1
@@ -57,19 +57,18 @@ $image = (Get-WimFileImagesInfo -WimFilePath $wimFilePath)[1]
 # The path were you want to create the config fille
 $configFilePath = Join-Path $scriptPath "Examples\config.ini"
 New-WindowsImageConfig -ConfigFilePath $configFilePath
-$fCfgPath = Resolve-Path $configFilePath
 
 #This is an example how to automate the image configuration file according to your needs
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "wim_file_path" -Value $wimFilePath
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "image_name" -Value $image.ImageName
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "image_path" -Value $virtualDiskPath
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "virtual_disk_format" -Value "RAW"
-Set-IniFileValue -Path $fCfgPath -Section "vm" -Key "disk_size" -Value (30GB)
-Set-IniFileValue -Path $fCfgPath -Section "drivers" -Key "virtio_iso_path" -Value $virtIOISOPath
-Set-IniFileValue -Path $fCfgPath -Section "drivers" -Key "drivers_path" -Value $extraDriversPath
-Set-IniFileValue -Path $fCfgPath -Section "updates" -Key "install_updates" -Value "True"
-Set-IniFileValue -Path $fCfgPath -Section "updates" -Key "purge_updates" -Value "True"
-Set-IniFileValue -Path $fCfgPath -Section "sysprep" -Key "disable_swap" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "wim_file_path" -Value $wimFilePath
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "image_name" -Value $image.ImageName
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "image_path" -Value $virtualDiskPath
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "virtual_disk_format" -Value "RAW"
+Set-IniFileValue -Path $configFilePath -Section "vm" -Key "disk_size" -Value (30GB)
+Set-IniFileValue -Path $configFilePath -Section "drivers" -Key "virtio_iso_path" -Value $virtIOISOPath
+Set-IniFileValue -Path $configFilePath -Section "drivers" -Key "drivers_path" -Value $extraDriversPath
+Set-IniFileValue -Path $configFilePath -Section "updates" -Key "install_updates" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "updates" -Key "purge_updates" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "sysprep" -Key "disable_swap" -Value "True"
 
 # This scripts generates a raw image file that, after being started as an instance and
 # after it shuts down, it can be used with Ironic or KVM hypervisor in OpenStack.

--- a/Examples/create-windows-online-cloud-image.ps1
+++ b/Examples/create-windows-online-cloud-image.ps1
@@ -62,23 +62,22 @@ $switchName = 'external'
 # The path were you want to create the config fille
 $configFilePath = Join-Path $scriptPath "Examples\config.ini"
 New-WindowsImageConfig -ConfigFilePath $configFilePath
-$fCfgPath = Resolve-Path $configFilePath
 
 #This is an example how to automate the image configuration file according to your needs
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "wim_file_path" -Value $wimFilePath
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "image_name" -Value $image.ImageName
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "image_path" -Value $windowsImagePath
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "image_type" -Value "MAAS"
-Set-IniFileValue -Path $fCfgPath -Section "Default" -Key "install_maas_hooks" -Value "True"
-Set-IniFileValue -Path $fCfgPath -Section "vm" -Key "cpu_count" -Value 4
-Set-IniFileValue -Path $fCfgPath -Section "vm" -Key "ram_size" -Value (4GB)
-Set-IniFileValue -Path $fCfgPath -Section "vm" -Key "disk_size" -Value (30GB)
-Set-IniFileValue -Path $fCfgPath -Section "vm" -Key "external_switch" -Value $switchName
-Set-IniFileValue -Path $fCfgPath -Section "drivers" -Key "virtio_iso_path" -Value $virtIOISOPath
-Set-IniFileValue -Path $fCfgPath -Section "drivers" -Key "drivers_path" -Value $extraDriversPath
-Set-IniFileValue -Path $fCfgPath -Section "updates" -Key "install_updates" -Value "True"
-Set-IniFileValue -Path $fCfgPath -Section "updates" -Key "purge_updates" -Value "True"
-Set-IniFileValue -Path $fCfgPath -Section "sysprep" -Key "disable_swap" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "wim_file_path" -Value $wimFilePath
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "image_name" -Value $image.ImageName
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "image_path" -Value $windowsImagePath
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "image_type" -Value "MAAS"
+Set-IniFileValue -Path $configFilePath -Section "Default" -Key "install_maas_hooks" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "vm" -Key "cpu_count" -Value 4
+Set-IniFileValue -Path $configFilePath -Section "vm" -Key "ram_size" -Value (4GB)
+Set-IniFileValue -Path $configFilePath -Section "vm" -Key "disk_size" -Value (30GB)
+Set-IniFileValue -Path $configFilePath -Section "vm" -Key "external_switch" -Value $switchName
+Set-IniFileValue -Path $configFilePath -Section "drivers" -Key "virtio_iso_path" -Value $virtIOISOPath
+Set-IniFileValue -Path $configFilePath -Section "drivers" -Key "drivers_path" -Value $extraDriversPath
+Set-IniFileValue -Path $configFilePath -Section "updates" -Key "install_updates" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "updates" -Key "purge_updates" -Value "True"
+Set-IniFileValue -Path $configFilePath -Section "sysprep" -Key "disable_swap" -Value "True"
 
 # This scripts generates a raw tar.gz-ed image file, that can be used with MAAS
 New-WindowsOnlineImage -ConfigFilePath $configFilePath

--- a/UnattendResources/ini.psm1
+++ b/UnattendResources/ini.psm1
@@ -73,6 +73,7 @@ function Get-IniFileValue
     )
     process
     {
+        $Path = Resolve-Path $Path
         $sb = New-Object -TypeName "System.Text.StringBuilder" -ArgumentList 1000
         $retVal = [PSCloudbase.Win32IniApi]::GetPrivateProfileString($Section, $Key, $Default, $sb, $sb.Capacity, $Path)
         if (!$retVal)
@@ -122,6 +123,7 @@ function Set-IniFileValue
     )
     process
     {
+        $Path = Resolve-Path $Path
         $retVal = [PSCloudbase.Win32IniApi]::WritePrivateProfileString($Section, $Key, $Value, $Path)
         if (!$retVal -and [PSCloudbase.Win32IniApi]::GetLastError())
         {
@@ -149,6 +151,7 @@ function Remove-IniFileValue
     )
     process
     {
+        $Path = Resolve-Path $Path
         $retVal = [PSCloudbase.Win32IniApi]::WritePrivateProfileString($Section, $Key, $null, $Path)
         if (!$retVal -and [PSCloudbase.Win32IniApi]::GetLastError())
         {


### PR DESCRIPTION
The Set|Get|Remove-Ini commands were failing when the ini file
path was a relative path.

This path makes sure the relative paths are always converted
to absolute paths before the ini file change is executed.

Updated image geneeration examples, as they do not need the
relative to absolute path conversion.