### PR TITLE
Typecast $windowsImageConfig.cpu_count

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1175,7 +1175,7 @@ function New-WindowsOnlineImage {
                 -f $windowsImageConfig.external_switch
         }
     }
-    if ($windowsImageConfig.cpu_count -gt [int](Get-TotalLogicalProcessors)) {
+    if ([int]$windowsImageConfig.cpu_count -gt [int](Get-TotalLogicalProcessors)) {
         throw "CpuCores larger then available (logical) CPU cores."
     }
 
@@ -1403,7 +1403,7 @@ function New-WindowsFromGoldenImage {
                 -f $windowsImageConfig.external_switch
         }
     }
-    if ($windowsImageConfig.cpu_count -gt [int](Get-TotalLogicalProcessors)) {
+    if ([int]$windowsImageConfig.cpu_count -gt [int](Get-TotalLogicalProcessors)) {
         throw "CpuCores larger than available (logical) CPU cores."
     }
 


### PR DESCRIPTION
Typecast $windowsImageConfig.cpu_count to an integer so it can be more reliably compared against the number of logical processors.  Closes #219.