### PR TITLE
Add offline hook to install custom packages or kbs

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -147,7 +147,12 @@ function Get-AvailableConfigOptions {
         @{"Name" = "compress_qcow2"; "DefaultValue" = $false; "AsBoolean" = $true;
           "Description" = "If set to true and the target image format is QCOW2, the image conversion will
                            use qemu-img built-in compression. The compressed qcow2 image will be smaller, but the conversion
-                           will take longer time."}
+                           will take longer time."},
+        @{"Name" = "extra_packages";
+          "Description" = "A comma separated list of extra packages (referenced by filepath)
+                           to slipstream into the underlying image.
+                           This allows additional local packages, like security updates, to be added to the image."}
+
     )
 }
 

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -543,6 +543,20 @@ function Add-DriversToImage {
     }
 }
 
+function Add-PackageToImage {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$winImagePath,
+        [Parameter(Mandatory=$true)]
+        [string]$packagePath
+    )
+    Write-Log ('Adding packages from "{0}" to image "{1}"' -f $packagePath, $winImagePath)
+    & Dism.exe /image:${winImagePath} /Add-Package /Packagepath:${packagePath}
+    if ($LASTEXITCODE) {
+        throw "Dism failed to add packages from: $packagePath"
+    }
+}
+
 function Enable-FeaturesInImage {
     Param(
         [Parameter(Mandatory=$true)]
@@ -1336,6 +1350,12 @@ function New-WindowsCloudImage {
         }
         if ($windowsImageConfig.extra_features) {
             Enable-FeaturesInImage $winImagePath $windowsImageConfig.extra_features
+        }
+
+        if($windowsImageConfig.extra_packages) {
+            foreach ($package in $windowsImageConfig.extra_packages.split(",")) {
+                Add-PackageToImage $winImagePath $package
+            }
         }
     } finally {
         if (Test-Path $vhdPath) {


### PR DESCRIPTION
## Description
This pull request adds support to slipstream Microsoft KBs and other packages to an offline image via DISM.

It works by introducing a new Config parameter, `extra_packages`, that contains a comma separated list of filepaths to extra packages that will be installed directly into the underlying Windows image at image creation time.

The  `extra_packages` parameter can be used with either `New-WindowsOnlineImage` or `New-WindowsCloudImage` workflows.

## Example
```powershell
# find cumulative security updates and other kbs
$kb4457128 = "C:/Path/To/Some/Update/windows10.0-kb4457128-x64_ed9c4b8a5fd2a5d9f55873f8502e4f7495e5a47e.msu"

$kbs = @($kb4457128)

$slipstreamed_kbs =  $kbs -join ","
Set-IniFileValue -Path $configFilePath -Section "Default" -Key "extra_packages" -Value $slipstreamed_kbs

New-WindowsOnlineImage -ConfigFilePath $configFilePath

```

## Motivation
For my team, slipstreaming Microsoft Updates at offline image generation time improved provisioning speed when compared to purely online updates. 

Adding this hook lets us pre-load our images with the latest cumulative security updates and drastically improves the time it takes for the online updates to complete (since there's far fewer updates to download and install).

This was especially true for very old images (like Windows 7), which tend to pile up multiple large security updates prior to a major service pack release.

 _The network disk backend on our cloud service was particularly slow, which only exacerbated the time it took to complete online updates. This obviously improves when moving towards things like Windows Server 1803, which has a more frequent update cadence, but we still found the `extra_packages` customization point helpful and figured we'd share :)_
