### PR TITLE
Added support for Windows 10 VirtIO drivers

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1043,7 +1043,9 @@ function Get-ImageInformation {
         $imageArchitecture = "i386"
     }
 
-    if ($imageName -like '*Core') {
+    if ($imageName -notlike "*server*") {
+        $imageInstallationType = "Client"
+    } elseif ($imageName -like '*Core') {
         $imageInstallationType = "Server Core"
     } else {
         $imageInstallationType = "Server"


### PR DESCRIPTION
The VirtIO drivers would fail to install on Windows 10 editions
because the directory mapping for the driver was missing.
Also added support for the "Client" imageInstallationType.
Addressing issue #226