### PR TITLE
Add config to ignore extra_packages errors

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -159,6 +159,9 @@ function Get-AvailableConfigOptions {
           "Description" = "A comma separated list of extra packages (referenced by filepath)
                            to slipstream into the underlying image.
                            This allows additional local packages, like security updates, to be added to the image."}
+        @{"Name" = "extra_packages_ignore_errors"; "DefaultValue" = $false; "AsBoolean" = $true;
+          "Description" = "Ignore failures from DISM when installing extra_packages, such as when
+                           updates are skipped which are not applicable to the image."}
 
     )
 }

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -569,12 +569,16 @@ function Add-PackageToImage {
         [Parameter(Mandatory=$true)]
         [string]$winImagePath,
         [Parameter(Mandatory=$true)]
-        [string]$packagePath
+        [string]$packagePath,
+        [Parameter(Mandatory=$false)]
+        [boolean]$ignoreErrors
     )
     Write-Log ('Adding packages from "{0}" to image "{1}"' -f $packagePath, $winImagePath)
     & Dism.exe /image:${winImagePath} /Add-Package /Packagepath:${packagePath}
-    if ($LASTEXITCODE) {
+    if ($LASTEXITCODE -and !$ignoreErrors) {
         throw "Dism failed to add packages from: $packagePath"
+    } elseif ($LASTEXITCODE) {
+        Write-Log ("Dism failed to add packages from $packagePath. Skipping.")
     }
 }
 
@@ -1397,7 +1401,7 @@ function New-WindowsCloudImage {
         }
         if ($windowsImageConfig.extra_packages) {
             foreach ($package in $windowsImageConfig.extra_packages.split(",")) {
-                Add-PackageToImage $winImagePath $package
+                Add-PackageToImage $winImagePath $package -ignoreErrors $windowsImageConfig.extra_packages_ignore_errors
             }
         }
         if ($windowsImageConfig.extra_capabilities) {


### PR DESCRIPTION
When installing a directory full of updates, such as from wsusoffline,
there are inevitably some packages which are "not applicable to this
image". When this happens, DISM returns a nonzero exit code and the
image build fails. This configuration allows the user to ignore these
errors and proceed with the image build anyway.