### PR TITLE
InstallMaasHooks and VMwareToolsPath added to WindowsFromGoldenImage

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1427,7 +1427,9 @@ function New-WindowsFromGoldenImage {
         }
 
         $resourcesDir = Join-Path -Path $driveLetterGold -ChildPath "UnattendResources"
-        Copy-UnattendResources -resourcesDir $resourcesDir -imageInstallationType $windowsImageConfig.image_name
+        Copy-UnattendResources -resourcesDir $resourcesDir -imageInstallationType $windowsImageConfig.image_name `
+                               -InstallMaaSHooks $windowsImageConfig.install_maas_hooks `
+                               -VMwareToolsPath $windowsImageConfig.vmware_tools_path
         Copy-CustomResources -ResourcesDir $resourcesDir -CustomResources $windowsImageConfig.custom_resources_path `
                              -CustomScripts $windowsImageConfig.custom_scripts_path
         Copy-Item $ConfigFilePath "$resourcesDir\config.ini"


### PR DESCRIPTION
Copy-UnattendedResources would fail to install the MaaS hooks because
the InstallMaasHooks parameter was missing during the function
call from inside New-WindowsFromGoldenImage