### PR TITLE
Adding /Add-Capability support

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -44,6 +44,9 @@ function Get-AvailableConfigOptions {
         @{"Name" = "extra_features";
           "Description" = "A comma separated array of extra features that will be enabled on the resulting image.
                            These features need to be present in the ISO file."},
+        @{"Name" = "extra_capabilities";
+          "Description" = "A comma separated array of extra capabilities that will be enabled on the resulting image.
+                           These capabilities need to be present in the ISO file."},
         @{"Name" = "force"; "DefaultValue" = $false; "AsBoolean" = $true;
           "Description" = "It will force the image generation when RunSysprep is False or the selected SwitchName
                            is not an external one. Use this parameter with caution because it can easily generate

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1352,7 +1352,7 @@ function New-WindowsCloudImage {
             }
         }
         if ($windowsImageConfig.extra_capabilities) {
-            Add-CapabilitiesInImage $winImagePath $windowsImageConfig.extra_capabilities
+            Add-CapabilitiesToImage $winImagePath $windowsImageConfig.extra_capabilities
         }
     } finally {
         if (Test-Path $vhdPath) {


### PR DESCRIPTION
From Windows 1809 and Windows Server 2019 there is a new DISM Features on Demand /Add-Capability toggle. This PR adds the possibility to leverage it. Useful to enable SSH server in the image for example. 