### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Examples/config.ini
+*.swp


### PR DESCRIPTION
Examples/config.ini usually gets overwritten by the example scripts.
Therefore it should be ignored in git.
And while we are there, ignore vim .swp files as well