### PR TITLE
Optimize VHD to reduce image size

### DIFF
--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -141,6 +141,7 @@ Describe "Test Resize-VHDImage" {
     function Mount-VHD { }
     function Resize-VHD { }
     function Dismount-VHD { }
+    function Optimize-VHD { }
     Mock Write-Host -Verifiable -ModuleName $moduleName { return 0 }
     Mock Get-VHD -Verifiable -ModuleName $moduleName { return @{"Size" = 100; "MinimumSize" = 10} }
     Mock Mount-VHD -Verifiable -ModuleName $moduleName {
@@ -165,6 +166,8 @@ Describe "Test Resize-VHDImage" {
     Mock Resize-Partition -Verifiable -ModuleName $moduleName { return 0 }
     Mock Resize-VHD -Verifiable -ModuleName $moduleName { return 0 }
     Mock Dismount-VHD -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Get-Item -Verifiable -ModuleName $moduleName { return @{"Length"=100} }
+    Mock Optimize-VHD -Verifiable -ModuleName $moduleName { return 0 }
 
     It "Should resize a vhd image" {
         Resize-VHDImage -VirtualDiskPath "fakePath" `

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -950,7 +950,7 @@ function Resize-VHDImage {
         $NewSize = $newSizeGB*1GB
         Write-Log "New partition size: $newSizeGB GB"
 
-        if ($NewSize -gt $MinSize) {
+        if (($NewSize - $FreeSpace) -gt $MinSize) {
             $global:i = 0
             $step = 100MB
             Execute-Retry {
@@ -972,6 +972,12 @@ function Resize-VHDImage {
     }
     $FinalDiskSize = ((Get-VHD -Path $VirtualDiskPath).Size/1GB)
     Write-Log "Final disk size: $FinalDiskSize GB"
+
+    $virtualDiskFileSize = (Get-Item -Path $VirtualDiskPath).Length / 1GB
+    Write-Log "Optimize VHD ${VirtualDiskPath}: file size before optimization is ${virtualDiskFileSize} GB"
+    Optimize-VHD $VirtualDiskPath -Mode Full
+    $finalVirtualDiskFileSize = (Get-Item -Path $VirtualDiskPath).Length / 1GB
+    Write-Log "Optimize VHD ${VirtualDiskPath}: file size after optimization is ${finalVirtualDiskFileSize} GB"
 }
 
 function Check-Prerequisites {


### PR DESCRIPTION
Changes:

* Use Optimize-VHD to optimize the allocation of space. The Compact operation is used to optimize the files. This operation reclaims unused blocks as well as rearranges the blocks to be more efficiently packed, which reduces the size of a virtual hard disk file.

To use Optimize-VHD, the virtual hard disk must not be attached or must be attached in read-only mode. 
* hyper-v: remove auto-checkpoint and use static memory

Windows 10 1903 version creates automated checkpoints by
default, which can add a delay in the image generation time.

Static memory is also enabled, as dynamic memory adds a penalty
in the VM performance.
