### PR TITLE
Add support for Windows Server 2019

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -151,6 +151,10 @@ function Get-AvailableConfigOptions {
           "Description" = "If set to true and the target image format is QCOW2, the image conversion will
                            use qemu-img built-in compression. The compressed qcow2 image will be smaller, but the conversion
                            will take longer time."},
+        @{"Name" = "zero_unused_volume_sectors"; "DefaultValue" = $false; "AsBoolean" = $true;
+          "Description" = "If set to true, during final cleanup, https://github.com/felfert/ntfszapfree will be used to zero unused space.
+                           This helps qemu-img to minimize image size. In order to benefit from this, an additional invocation
+                           of qemu-img convert has to be performed after the initial run of the image has shutdown."},
         @{"Name" = "extra_packages";
           "Description" = "A comma separated list of extra packages (referenced by filepath)
                            to slipstream into the underlying image.

--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -101,6 +101,7 @@ Describe "Test New-WindowsCloudImage" {
     Mock Copy-CustomResources -Verifiable -ModuleName $moduleName { return 0 }
     Mock Copy-Item -Verifiable -ModuleName $moduleName { return 0 }
     Mock Download-CloudbaseInit -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Download-ZapFree -Verifiable -ModuleName $moduleName { return 0 }
     Mock Apply-Image -Verifiable -ModuleName $moduleName { return 0 }
     Mock Create-BCDBootConfig -Verifiable -ModuleName $moduleName { return 0 }
     Mock Check-EnablePowerShellInImage -Verifiable -ModuleName $moduleName { return 0 }

--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -141,6 +141,7 @@ Describe "Test Resize-VHDImage" {
     function Mount-VHD { }
     function Resize-VHD { }
     function Dismount-VHD { }
+    function Optimize-VHD { }
     Mock Write-Host -Verifiable -ModuleName $moduleName { return 0 }
     Mock Get-VHD -Verifiable -ModuleName $moduleName { return @{"Size" = 100; "MinimumSize" = 10} }
     Mock Mount-VHD -Verifiable -ModuleName $moduleName {
@@ -165,6 +166,8 @@ Describe "Test Resize-VHDImage" {
     Mock Resize-Partition -Verifiable -ModuleName $moduleName { return 0 }
     Mock Resize-VHD -Verifiable -ModuleName $moduleName { return 0 }
     Mock Dismount-VHD -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Get-Item -Verifiable -ModuleName $moduleName { return @{"Length"=100} }
+    Mock Optimize-VHD -Verifiable -ModuleName $moduleName { return 0 }
 
     It "Should resize a vhd image" {
         Resize-VHDImage -VirtualDiskPath "fakePath" `

--- a/Tests/fake-config.ini
+++ b/Tests/fake-config.ini
@@ -10,6 +10,7 @@ force = false
 zip_password = ""
 install_maas_hooks = false
 compression_format = tar.gz
+zero_unused_volume_sectors = true
 
 [vm]
 administrator_password = Pa$$w0rd

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -68,6 +68,16 @@ function Set-UnattendEnableSwap {
     $xml.Save($Path)
 }
 
+function Optimize-SparseImage {
+    $zapfree = "$resourcesDir\zapfree.exe"
+    if ( Test-Path $zapfree ) {
+        Write-Host "Optimizing for sparse image..."
+        & $zapfree -z $ENV:SystemDrive
+    } else {
+        Write-Debug "No zapfree. Image not optimized."
+    }
+}
+
 function Clean-UpdateResources {
     $HOST.UI.RawUI.WindowTitle = "Running update resources cleanup"
     # We're done, disable AutoLogon
@@ -392,6 +402,7 @@ try
         Set-UnattendEnableSwap -Path $unattendedXmlPath
     }
     Run-CustomScript "RunBeforeSysprep.ps1"
+    Optimize-SparseImage
     & "$ENV:SystemRoot\System32\Sysprep\Sysprep.exe" `/generalize `/oobe `/shutdown `/unattend:"$unattendedXmlPath"
     Run-CustomScript "RunAfterSysprep.ps1"
     Clean-UpdateResources

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1355,7 +1355,7 @@ function New-WindowsCloudImage {
         }
         if ($windowsImageConfig.virtio_iso_path) {
             Add-VirtIODriversFromISO -vhdDriveLetter $winImagePath -image $image `
-                -driversBasePath $windowsImageConfig.virtio_iso_path
+                -isoPath $windowsImageConfig.virtio_iso_path
         }
         if ($windowsImageConfig.virtio_base_path) {
             Add-VirtIODrivers -vhdDriveLetter $winImagePath -image $image `

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -19,6 +19,9 @@ $localResourcesDir = "$scriptPath\UnattendResources"
 Import-Module "$scriptPath\Config.psm1"
 Import-Module "$scriptPath\UnattendResources\ini.psm1"
 
+# Enforce Tls1.2, as GitHub and more websites require it.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $noHypervWarning = @"
 The Hyper-V role is missing from this machine. In order to be able to finish
 generating the image, you need to install the Hyper-V role.

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -421,7 +421,7 @@ function Copy-UnattendResources {
         New-Item -Type Directory $resourcesDir | Out-Null
     }
     Write-Log "Copying: $localResourcesDir $resourcesDir"
-    Copy-Item -Recurse "$localResourcesDir\*" $resourcesDir
+    Copy-Item -Recurse -Force "$localResourcesDir\*" $resourcesDir
 
     if ($InstallMaaSHooks) {
         $src = Join-Path $localResourcesDir "windows-curtin-hooks\curtin"
@@ -950,7 +950,7 @@ function Resize-VHDImage {
         $NewSize = $newSizeGB*1GB
         Write-Log "New partition size: $newSizeGB GB"
 
-        if ($NewSize -gt $MinSize) {
+        if (($NewSize - $FreeSpace) -gt $MinSize) {
             $global:i = 0
             $step = 100MB
             Execute-Retry {
@@ -972,6 +972,12 @@ function Resize-VHDImage {
     }
     $FinalDiskSize = ((Get-VHD -Path $VirtualDiskPath).Size/1GB)
     Write-Log "Final disk size: $FinalDiskSize GB"
+
+    $virtualDiskFileSize = (Get-Item -Path $VirtualDiskPath).Length / 1GB
+    Write-Log "Optimize VHD ${VirtualDiskPath}: file size before optimization is ${virtualDiskFileSize} GB"
+    Optimize-VHD $VirtualDiskPath -Mode Full
+    $finalVirtualDiskFileSize = (Get-Item -Path $VirtualDiskPath).Length / 1GB
+    Write-Log "Optimize VHD ${VirtualDiskPath}: file size after optimization is ${finalVirtualDiskFileSize} GB"
 }
 
 function Check-Prerequisites {
@@ -986,7 +992,7 @@ function Wait-ForVMShutdown {
         [Parameter(Mandatory=$true)]
         [string]$Name
     )
-    Write-Log "Waiting for $Name to finish sysprep"
+    Write-Log "Waiting for $Name to finish sysprep."
     $isOff = (Get-VM -Name $Name).State -eq "Off"
     while ($isOff -eq $false) {
         Start-Sleep 1
@@ -1072,8 +1078,8 @@ function Set-WindowsWallpaper {
         [string]$WallpaperSolidColor
     )
 
+    Write-Log "Setting wallpaper..."
     $useWallpaperImage = $false
-    Write-Log "Set Wallpaper: $WallpaperPath..."
     $wallpaperGPOPath = Join-Path $localResourcesDir "GPO"
 
     if ($WallpaperPath -and $WallpaperSolidColor) {
@@ -1449,8 +1455,11 @@ function New-WindowsFromGoldenImage {
 
         $driveNumber = (Get-DiskImage -ImagePath $windowsImageConfig.gold_image_path | Get-Disk).Number
         $maxPartitionSize = (Get-PartitionSupportedSize -DiskNumber $driveNumber -PartitionNumber 1).SizeMax
-        Resize-Partition -DiskNumber $driveNumber -PartitionNumber 1 -Size $maxPartitionSize
-
+        try {
+            Resize-Partition -DiskNumber $driveNumber -PartitionNumber 1 -Size $maxPartitionSize -ErrorAction SilentlyContinue
+        } catch {
+            Write-Log "Partition has already the desired size"
+        }
         $imageInfo = Get-ImageInformation $driveLetterGold -ImageName $windowsImageConfig.image_name
         if ($windowsImageConfig.virtio_iso_path) {
             Add-VirtIODriversFromISO -vhdDriveLetter $driveLetterGold -image $imageInfo `
@@ -1476,13 +1485,22 @@ function New-WindowsFromGoldenImage {
             -WallpaperSolidColor $windowsImageConfig.wallpaper_solid_color
         Download-CloudbaseInit $resourcesDir $imageInfo.imageArchitecture -BetaRelease:$windowsImageConfig.beta_release `
                                $windowsImageConfig.msi_path
-        Dismount-VHD -Path $windowsImageConfig.gold_image_path
+        Dismount-VHD -Path $windowsImageConfig.gold_image_path | Out-Null
 
         $Name = "WindowsGoldImage-Sysprep" + (Get-Random)
 
-        New-VM -Name $Name -MemoryStartupBytes $windowsImageConfig.ram_size -SwitchName $switch.Name `
-            -VHDPath $windowsImageConfig.gold_image_path | Out-Null
-        Set-VMProcessor -VMname $Name -count $windowsImageConfig.cpu_count
+        $vm = New-VM -Name $Name -MemoryStartupBytes $windowsImageConfig.ram_size -SwitchName $switch.Name `
+            -VHDPath $windowsImageConfig.gold_image_path
+        Set-VMProcessor -VMname $Name -count $windowsImageConfig.cpu_count | Out-Null
+        Set-VMMemory -VMname $Name -DynamicMemoryEnabled:$false | Out-Null
+        $vmAutomaticCheckpointsEnabledWrapper = $vm | Select-Object 'AutomaticCheckpointsEnabled' -ErrorAction SilentlyContinue
+        $vmAutomaticCheckpointsEnabled = $false
+        if ($vmAutomaticCheckpointsEnabledWrapper) {
+            $vmAutomaticCheckpointsEnabled = $vmAutomaticCheckpointsEnabledWrapper.AutomaticCheckpointsEnabled
+        }
+        if ($vmAutomaticCheckpointsEnabled) {
+            Set-VM -VMName $Name -AutomaticCheckpointsEnabled:$false
+        }
 
         Start-VM $Name | Out-Null
         Start-Sleep 10

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -38,15 +38,16 @@ $VirtIODrivers = @("balloon", "netkvm", "pvpanic", "qemupciserial", "qxl",
              "qxldod", "vioinput", "viorng", "vioscsi", "vioserial", "viostor")
 
 $VirtIODriverMappings = @{
-    "2k8" = @(60, 1);
-    "2k8r2" = @(61, 1);
-    "w7" = @(61, 0);
-    "2k12" = @(62, 1);
-    "w8" = @(62, 0);
-    "2k12r2" = @(63, 1);
-    "w8.1" = @(63, 0);
-    "2k16" = @(100, 1);
-    "w10" = @(100, 0);
+    "2k8" = @(60, 0, 1);
+    "2k8r2" = @(61, 0, 1);
+    "w7" = @(61, 0, 0);
+    "2k12" = @(62, 0, 1);
+    "w8" = @(62, 0, 0);
+    "2k12r2" = @(63, 0, 1);
+    "w8.1" = @(63, 0, 0);
+    "2k16" = @(100, 14393, 1);
+    "2k19" = @(100, 17763, 1);
+    "w10" = @(100, 0, 0);
 }
 
 $AvailableCompressionFormats = @("tar","gz","zip")
@@ -668,6 +669,8 @@ function Get-VirtIODrivers {
         [parameter(Mandatory=$true)]
         [int]$MajorMinorVersion,
         [parameter(Mandatory=$true)]
+        [int]$BuildNumber,
+        [parameter(Mandatory=$true)]
         [int]$IsServer,
         [parameter(Mandatory=$true)]
         [string]$BasePath,
@@ -682,7 +685,10 @@ function Get-VirtIODrivers {
     foreach ($driver in $VirtioDrivers) {
         foreach ($osVersion in $VirtIODriverMappings.Keys) {
             $map = $VirtIODriverMappings[$osVersion]
-            if (!(($map[0] -eq $MajorMinorVersion) -and ($map[1] -eq $isServer))) {
+            if (!(($map[0] -eq $MajorMinorVersion) -and ($map[2] -eq $isServer))) {
+              continue
+            }
+            if (($map[1] -ne 0) -and ($map[1] -ne $BuildNumber)) {
               continue
             }
             $driverPath = "{0}\{1}\{2}\{3}" -f @($basePath,
@@ -697,7 +703,7 @@ function Get-VirtIODrivers {
     }
     if (!$driverPaths -and $RecursionDepth -lt 1) {
         # Note(avladu): Fallback to 2012r2/w8.1 if no drivers are found
-        $driverPaths = Get-VirtIODrivers -MajorMinorVersion 63 -IsServer $IsServer `
+        $driverPaths = Get-VirtIODrivers -MajorMinorVersion 63 -BuildNumber 0 -IsServer $IsServer `
             -BasePath $BasePath -Architecture $Architecture -RecursionDepth 1
     }
     return $driverPaths
@@ -738,8 +744,8 @@ function Add-VirtIODrivers {
     # For VirtIO ISO with drivers version higher than 1.8.x
     $majorMinorVersion = [string]$image.ImageVersion.Major + [string]$image.ImageVersion.Minor
     $virtioDriversPaths = Get-VirtIODrivers -MajorMinorVersion $majorMinorVersion `
-        -IsServer ([int](Is-ServerInstallationType $image)) -BasePath $driversBasePath `
-        -Architecture $image.ImageArchitecture
+        -BuildNumber $image.ImageVersion.Build -IsServer ([int](Is-ServerInstallationType $image)) `
+        -BasePath $driversBasePath -Architecture $image.ImageArchitecture
     foreach ($virtioDriversPath in $virtioDriversPaths) {
         if (Test-Path $virtioDriversPath) {
             Add-DriversToImage $vhdDriveLetter $virtioDriversPath


### PR DESCRIPTION
This PR adds support for Windows Server 2019, using latest [virtio-win-0.1.171](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.171-1/virtio-win-0.1.171.iso)

While testing, I also found out, that the fallback to win2k12r2 drivers in WinImageBuilder.ps1, line 697 is probably a bad idea, because no error or warning is printed, but a non-functional image is generated.
This should be replaced by fatal error, clearly stating that the appropriate drivers are missing.