### PR TITLE
Added option shrink_image_to_minimum_size=True|False

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -99,8 +99,10 @@ function Get-AvailableConfigOptions {
           "Description" = "The number of CPU cores assigned to the VM used to generate the image."},
         @{"Name" = "ram_size"; "GroupName" = "vm"; "DefaultValue" = "2147483648";
           "Description" = "RAM (in bytes) assigned to the VM used to generate the image."},
-        @{"Name" = "disk_size"; "GroupName" = "vm"; "DefaultValue" = "42949672960";
-          "Description" = "Disk space (in bytes) assigned to the VM used to generate the image."},
+        @{"Name" = "disk_size"; "GroupName" = "vm"; "DefaultValue" = "42949672960,";
+          "Description" = "Disk space (in bytes) assigned to the boot disk  for the VM used to generate the image."},
+        @{"Name" = "shrink_image_to_minimum_size"; "DefaultValue" = $true; "AsBoolean" = $true
+          "Description" = "Whether to shrink the image partition and disk after the image generation is complete."},
         @{"Name" = "virtio_iso_path"; "GroupName" = "drivers";
           "Description" = "The path to the ISO file containing the VirtIO drivers."},
         @{"Name" = "virtio_base_path"; "GroupName" = "drivers";

--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -142,7 +142,6 @@ Describe "Test Resize-VHDImage" {
     function Mount-VHD { }
     function Resize-VHD { }
     function Dismount-VHD { }
-    function Optimize-VHD { }
     Mock Write-Host -Verifiable -ModuleName $moduleName { return 0 }
     Mock Get-VHD -Verifiable -ModuleName $moduleName { return @{"Size" = 100; "MinimumSize" = 10} }
     Mock Mount-VHD -Verifiable -ModuleName $moduleName {
@@ -167,8 +166,6 @@ Describe "Test Resize-VHDImage" {
     Mock Resize-Partition -Verifiable -ModuleName $moduleName { return 0 }
     Mock Resize-VHD -Verifiable -ModuleName $moduleName { return 0 }
     Mock Dismount-VHD -Verifiable -ModuleName $moduleName { return 0 }
-    Mock Get-Item -Verifiable -ModuleName $moduleName { return @{"Length"=100} }
-    Mock Optimize-VHD -Verifiable -ModuleName $moduleName { return 0 }
 
     It "Should resize a vhd image" {
         Resize-VHDImage -VirtualDiskPath "fakePath" `
@@ -182,6 +179,8 @@ Describe "Test Resize-VHDImage" {
 
 
 Describe "Test New-WindowsOnlineImage" {
+    function Optimize-VHD { }
+
     Mock Write-Host -Verifiable -ModuleName $moduleName { return 0 }
     Mock Is-Administrator -Verifiable -ModuleName $moduleName { return 0 }
     Mock Check-Prerequisites -Verifiable -ModuleName $moduleName { return 0 }
@@ -193,6 +192,7 @@ Describe "Test New-WindowsOnlineImage" {
     Mock Get-Random -Verifiable -ModuleName $moduleName { return 1 }
     Mock Remove-Item -Verifiable -ModuleName $moduleName { return 0 }
     Mock Compress-Image -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Optimize-VHD -Verifiable -ModuleName $moduleName { return 0 }
     Mock Get-VMSwitch -Verifiable -ModuleName $moduleName { return @{"Name"="external";"SwitchType"="External"} }
 
     It "Should create an online image" {


### PR DESCRIPTION
Added option shrink_image_to_minimum_size which defaults to True,
to create images that have a fixed size, defined by the value of
disk_size.

Optimize-VHD had to be kept as the VHD optimization does not
change the internal size of the disk.