### PR TITLE
Added option enable_custom_wallpaper=True|False

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -140,6 +140,9 @@ function Get-AvailableConfigOptions {
         @{"Name" = "msi_path"; "GroupName" = "cloudbase_init";
           "Description" = "If set, the Cloudbase-Init msi at this path will be used.
                           The path needs to be a locally accesible file path."},
+        @{"Name" = "enable_custom_wallpaper"; "DefaultValue" = $true; "AsBoolean" = $true;
+          "Description" = "If set to true, a custom wallpaper will be set according to the values of configuration options
+                           wallpaper_path and wallpaper_solid_color"},
         @{"Name" = "wallpaper_path";
           "Description" = "If set, it will replace the Cloudbase Solutions wallpaper to the one specified.
                            The wallpaper needs to be a valid .jpg/.jpeg image."},

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1377,8 +1377,10 @@ function New-WindowsCloudImage {
         Copy-CustomResources -ResourcesDir $resourcesDir -CustomResources $windowsImageConfig.custom_resources_path `
                              -CustomScripts $windowsImageConfig.custom_scripts_path
         Copy-Item $ConfigFilePath "$resourcesDir\config.ini"
-        Set-WindowsWallpaper -WinDrive $winImagePath -WallpaperPath $windowsImageConfig.wallpaper_path `
-            -WallpaperSolidColor $windowsImageConfig.wallpaper_solid_color
+        if ($windowsImageConfig.enable_custom_wallpaper) {
+            Set-WindowsWallpaper -WinDrive $winImagePath -WallpaperPath $windowsImageConfig.wallpaper_path `
+                -WallpaperSolidColor $windowsImageConfig.wallpaper_solid_color
+        }
         if ($windowsImageConfig.zero_unused_volume_sectors) {
             Download-ZapFree $resourcesDir ([string]$image.ImageArchitecture)
         }
@@ -1521,8 +1523,10 @@ function New-WindowsFromGoldenImage {
         Copy-CustomResources -ResourcesDir $resourcesDir -CustomResources $windowsImageConfig.custom_resources_path `
                              -CustomScripts $windowsImageConfig.custom_scripts_path
         Copy-Item $ConfigFilePath "$resourcesDir\config.ini"
-        Set-WindowsWallpaper -WinDrive $driveLetterGold -WallpaperPath $windowsImageConfig.wallpaper_path `
-            -WallpaperSolidColor $windowsImageConfig.wallpaper_solid_color
+        if ($windowsImageConfig.enable_custom_wallpaper) {
+            Set-WindowsWallpaper -WinDrive $driveLetterGold -WallpaperPath $windowsImageConfig.wallpaper_path `
+                -WallpaperSolidColor $windowsImageConfig.wallpaper_solid_color
+        }
         if ($windowsImageConfig.zero_unused_volume_sectors) {
             Download-ZapFree $resourcesDir $imageInfo.imageArchitecture
         }


### PR DESCRIPTION
If enable_custom_wallpaper is set to true, the wallpaper will be
customized. By default, the flag is enabled and the custom
Cloudbase Solutions wallpaper is used.