### PR TITLE
Fix Resize-Partition execution

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -999,12 +999,14 @@ function Resize-VHDImage {
         if (($NewSize - $FreeSpace) -gt $MinSize) {
             $global:i = 0
             $step = 100MB
+            # Adding 10 retries means increasing the size to a max of 1.5GB,
+            # which should be enough for the Resize-Partition to succeed.
             Execute-Retry {
                 $sizeIncreased = ($NewSize + ($step * $global:i))
                 Write-Log "Size increased: $sizeIncreased"
                 $global:i = $global:i + 1
                 Resize-Partition -DriveLetter $Drive -Size $sizeIncreased -ErrorAction "Stop"
-            }
+            } -maxRetryCount 10
         }
     }
     finally


### PR DESCRIPTION
The Resize-Partition can fail as the minimum partition size does
not coincide with the minimum resizeable partition size.

Fixes
https://github.com/cloudbase/windows-openstack-imaging-tools/issues/289