### PR TITLE
Fix image build from golden

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1814,7 +1814,6 @@ function New-WindowsFromGoldenImage {
         }
 
         if ($windowsImageConfig.compression_format) {
-            $imagePath = $windowsImageConfig['image_path']
             Compress-Image -VirtualDiskPath $imagePath `
                 -ImagePath $windowsImageConfig['image_path'] `
                 -compressionFormats $windowsImageConfig.compression_format `
@@ -1825,15 +1824,11 @@ function New-WindowsFromGoldenImage {
 
         Write-Log "Cloud image from golden image generation finished. Image path: $($windowsImageConfig.image_path)"
     } catch {
-        $vhdDismountLog = ""
         try {
             Get-VHD $windowsImageConfig.gold_image_path | Dismount-VHD
             Remove-Item -Force $windowsImageConfig.gold_image_path
         } catch {
-            $vhdDismountLog = $_
-        }
-        if ($vhdDismountLog) {
-            Write-Log $vhdDismountLog.Message
+            Write-Log $_
         }
         throw $_
     }


### PR DESCRIPTION
When the image is compressed, the imagePath should not be the config image path, as the target/destination of the compression should be different.