### PR TITLE
Allow image cleanup before packaging

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -190,7 +190,13 @@ function Get-AvailableConfigOptions {
           "Description" = "If set to true, it will set the High Performance mode and some power mode
                            and registry tweaks to prevent the machine from sleeping / hibernating."},
         @{"Name" = "disable_secure_boot"; "GroupName" = "vm"; "DefaultValue" = $false; "AsBoolean" = $true;
-          "Description" = "If set to true and the disk layout is UEFI, the secure boot firmware option will be disabled."}
+          "Description" = "If set to true and the disk layout is UEFI, the secure boot firmware option will be disabled."},
+        @{"Name" = "clean_updates_offline"; "GroupName" = "updates"; "DefaultValue" = $false; "AsBoolean" = $true;
+          "Description" = "Clean up the updates / components by running a DISM Cleanup-Image command.
+                           This is useful when updates or capabilities are installed offline."},
+        @{"Name" = "clean_updates_online"; "GroupName" = "updates"; "DefaultValue" = $true; "AsBoolean" = $true;
+          "Description" = "Clean up the updates / components by running a DISM Cleanup-Image command.
+                           This is useful when updates or other packages are installed when the instance is running."}
     )
 }
 

--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -70,9 +70,9 @@ function Compare-HashTables ($tab1, $tab2) {
     return $true
 }
 
-function Get-VMSwitch {
+function Get-VMSwitch {}
 
-}
+function Optimize-VHD {}
 
 Import-Module $modulePath
 
@@ -94,7 +94,7 @@ Describe "Test New-WindowsCloudImage" {
     Mock Test-Path -Verifiable -ModuleName $moduleName { return $false }
     Mock Create-ImageVirtualDisk -Verifiable -ModuleName $moduleName `
         {
-            return @("drive1")
+            return @("C:", "D:")
         }
     Mock Generate-UnattendXml -Verifiable -ModuleName $moduleName { return 0 }
     Mock Copy-UnattendResources -Verifiable -ModuleName $moduleName { return 0 }
@@ -107,6 +107,8 @@ Describe "Test New-WindowsCloudImage" {
     Mock Check-EnablePowerShellInImage -Verifiable -ModuleName $moduleName { return 0 }
     Mock Set-WindowsWallpaper -Verifiable -ModuleName $moduleName { return 0 }
     Mock Enable-FeaturesInImage -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Clean-WindowsUpdates -Verifiable -ModuleName $moduleName { return 0 }
+    Mock Optimize-Volume -Verifiable -ModuleName $moduleName { return 0 }
     Mock Get-PathWithoutExtension -Verifiable -ModuleName $moduleName { return "test" }
     Mock Compress-Image -Verifiable -ModuleName $moduleName { return 0 }
 
@@ -219,8 +221,6 @@ Describe "Test Resize-VHDImage with binary search" {
 
 
 Describe "Test New-WindowsOnlineImage" {
-    function Optimize-VHD { }
-
     Mock Write-Host -Verifiable -ModuleName $moduleName { return 0 }
     Mock Is-Administrator -Verifiable -ModuleName $moduleName { return 0 }
     Mock Check-Prerequisites -Verifiable -ModuleName $moduleName { return 0 }

--- a/Tests/fake-config.ini
+++ b/Tests/fake-config.ini
@@ -27,6 +27,7 @@ drivers_path = ""
 [updates]
 install_updates = false
 purge_updates = false
+clean_updates_offline = true
 
 [sysprep]
 run_sysprep = true

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1678,6 +1678,8 @@ function New-WindowsCloudImage {
             if ($windowsImageConfig.clean_updates_offline) {
                 Clean-WindowsUpdates $winImagePath -PurgeUpdates $windowsImageConfig.purge_updates
             }
+
+            Optimize-Volume -DriveLetter $drives[1].replace(":","") -Defrag -ReTrim -SlabConsolidate
         } finally {
             if (Test-Path $vhdPath) {
                 Detach-VirtualDisk $vhdPath


### PR DESCRIPTION
In the offline gold image builder, add config to enable DISM
Cleanup-Image to be run before packaging the image, so that
updates installed during the extra_packages phase can be cleaned
up before packaging.

The following new config options are added:
  * updates:clean_updates_offline, default false. If set,
    dism cleanup-image will be performed offline, after
    any offline updates / components / capabilities were installed.
  * updates:clean_updates_online, default true. If set,
    dism cleanup-image will be performed while the instance is running,
    after the updates were installed.