### PR TITLE
custom: Added custom timezone configuration

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -196,7 +196,9 @@ function Get-AvailableConfigOptions {
                            This is useful when updates or capabilities are installed offline."},
         @{"Name" = "clean_updates_online"; "GroupName" = "updates"; "DefaultValue" = $true; "AsBoolean" = $true;
           "Description" = "Clean up the updates / components by running a DISM Cleanup-Image command.
-                           This is useful when updates or other packages are installed when the instance is running."}
+                           This is useful when updates or other packages are installed when the instance is running."},
+        @{"Name" = "time_zone"; "GroupName" = "custom";
+          "Description" = "Set a custom timezone for the Windows image."}
     )
 }
 

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -407,6 +407,19 @@ function Enable-AlwaysActiveMode {
     Write-Log "AlwaysActive" "Always active mode was set."
 }
 
+function Set-CustomTimezone {
+    Param(
+        [parameter(Mandatory=$true)]
+        [String]$CustomTimezone
+    )
+
+    tzutil.exe /s "${CustomTimezone}"
+    if ($LastExitCode) {
+        throw "Failed to set custom timezone: ${CustomTimezone}"
+    }
+    Write-Log "Customization(1)" "Set timezone: ${CustomTimezone}"
+}
+
 try {
     Write-Log "StatusInitial" "Automated instance configuration started..."
     Import-Module "$resourcesDir\ini.psm1"
@@ -448,6 +461,9 @@ try {
     try {
         $cleanUpdatesOnline = Get-IniFileValue -Path $configIniPath -Section "updates" -Key "clean_updates_online" `
             -Default $true -AsBoolean
+    } catch{}
+    try {
+        $customTimezone = Get-IniFileValue -Path $configIniPath -Section "custom" -Key "time_zone"
     } catch{}
 
     if ($productKey) {
@@ -555,6 +571,10 @@ try {
 
     if ($enableAlwaysActiveMode) {
         Enable-AlwaysActiveMode
+    }
+
+    if ($customTimezone) {
+        Set-CustomTimezone $customTimezone
     }
 
     $Host.UI.RawUI.WindowTitle = "Running Sysprep..."


### PR DESCRIPTION
New config option time_zone was added in the 'custom' section.

Example:

[custom]
time_zone = "W. Europe Standard Time"

The time zone will be set during online stage, using:
tzutil.exe /s "W. Europe Standard Time"