### PR TITLE
Added custom ntp servers option

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -198,7 +198,9 @@ function Get-AvailableConfigOptions {
           "Description" = "Clean up the updates / components by running a DISM Cleanup-Image command.
                            This is useful when updates or other packages are installed when the instance is running."},
         @{"Name" = "time_zone"; "GroupName" = "custom";
-          "Description" = "Set a custom timezone for the Windows image."}
+          "Description" = "Set a custom timezone for the Windows image."},
+        @{"Name" = "ntp_servers"; "GroupName" = "custom";
+          "Description" = "Set custom ntp servers(space separated) for the Windows image"}
     )
 }
 

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -420,6 +420,20 @@ function Set-CustomTimezone {
     Write-Log "Customization(1)" "Set timezone: ${CustomTimezone}"
 }
 
+function Set-CustomNtpServers {
+    Param(
+        [parameter(Mandatory=$true)]
+        [String]$CustomNtpServers
+    )
+
+    w32tm.exe /config /syncfromflags:manual /manualpeerlist:"${CustomNtpServers}"
+    if ($LastExitCode) {
+        throw "Failed to set custom ntp servers: ${CustomNtpServers}"
+    }
+    Set-Service "W32time" -StartupType Automatic
+    Write-Log "Customization(2)" "Set ntp servers: ${CustomNtpServers}"
+}
+
 try {
     Write-Log "StatusInitial" "Automated instance configuration started..."
     Import-Module "$resourcesDir\ini.psm1"
@@ -464,6 +478,9 @@ try {
     } catch{}
     try {
         $customTimezone = Get-IniFileValue -Path $configIniPath -Section "custom" -Key "time_zone"
+    } catch{}
+    try {
+        $customNtpServers = Get-IniFileValue -Path $configIniPath -Section "custom" -Key "ntp_servers"
     } catch{}
 
     if ($productKey) {
@@ -575,6 +592,10 @@ try {
 
     if ($customTimezone) {
         Set-CustomTimezone $customTimezone
+    }
+
+    if ($customNtpServers) {
+        Set-CustomNtpServers $customNtpServers
     }
 
     $Host.UI.RawUI.WindowTitle = "Running Sysprep..."


### PR DESCRIPTION
New config option ntp_servers was added in the 'custom' section.

Example:

[custom]
ntp_servers = "0.ch.pool.ntp.org 1.ch.pool.ntp.org"

The ntp servers will be set during online stage, using:
w32tm.exe /config /syncfromflags:manual
/manualpeerlist:"${CustomNtpServers}"

The ntp servers are comma separated.

Fixes:
https://github.com/cloudbase/windows-openstack-imaging-tools/issues/314