### PR TITLE
Make qemu-img format lower caps

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -367,6 +367,7 @@ function Convert-VirtualDisk {
     )
 
     Write-Log "Convert Virtual Disk: $vhdPath..."
+    $format = $format.ToLower()
     $compressParam = ""
     if ($format -eq "qcow2" -and $CompressQcow2) {
         Write-Log "Qcow2 compression has been enabled."


### PR DESCRIPTION
The image format is required to be in lower caps,
otherwise qemu-img.exe will not recognize it.