### PR TITLE
Do not remove zip / tar archives

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -962,7 +962,6 @@ function Decompress-File {
             Write-Log "Decompressing tar ${imageName} to ${imageNameTar}"
             $tarCommand = @($7zip, "e", $imageName, "-y")
             Start-Executable -Command $tarCommand | Out-Null
-            Remove-Item -Force $imageName
             $imageName = $imageNameTar
         }
         if ($CompressionFormat -eq "gz") {
@@ -982,7 +981,6 @@ function Decompress-File {
                 $zipCommand += "-p$ZipPassword"
             }
             Start-Executable -Command $zipCommand | Out-Null
-            Remove-Item -Force $imageName
             $imageName = $imageNameZip
         }
     } finally {


### PR DESCRIPTION
When a compressed image is tested, the backing compressed files are erroneously removed, leading to removing the created image.
