### PR TITLE
Fix Is-WindowsClient condition

### DIFF
--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -603,11 +603,13 @@ try {
 
     Release-IP
 
+    $windowsClient = Is-WindowsClient
+
     if ($enableShutdownWithoutLogon) {
         Enable-ShutdownWithoutLogon
     }
 
-    if (Is-WindowsClient -and $disableFirstLogonAnimation) {
+    if ($windowsClient -and $disableFirstLogonAnimation) {
         Disable-FirstLogonAnimation
     }
 
@@ -619,7 +621,7 @@ try {
         Disable-IPv6TemporaryAddress
     }
 
-    if (Is-WindowsClient -and $enableAdministrator) {
+    if ($windowsClient -and $enableAdministrator) {
         Enable-AdministratorAccount
     }
 


### PR DESCRIPTION
First logon animation is always disabled and Administrator account is always enabled on Windows client versions because of bug in conditions that always return true.

```
> function Is-WindowsClient { return $true }
> if (Is-WindowsClient) { Write-Host $true } else { Write-Host $false }
True
> if (Is-WindowsClient -and $true) { Write-Host $true } else { Write-Host $false }
True
> if (Is-WindowsClient -and $false) { Write-Host $true } else { Write-Host $false }
True
```

To compare the return value of a function in a conditional we must put it in parentheses or assign the return value of the function to a variable and use that variable in the conditional. Otherwise we just call Is-WindowsClient with additional parameter $and = $false which is ignored.

Related discussion https://stackoverflow.com/questions/15930038/condition-with-a-function-call-in-powershell