### PR TITLE
Add option to set cloudbase-init service to auto-delayed start

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -150,6 +150,8 @@ function Get-AvailableConfigOptions {
         @{"Name" = "cloudbase_init_use_local_system"; "GroupName" = "cloudbase_init"; "AsBoolean" = $true; "DefaultValue" = $false;
           "Description" = "If set, the Cloudbase-Init service will be run under Local System account.
                            By default, a user named cloudbase-init with admin rights is created and used."},
+        @{"Name" = "cloudbase_init_delayed_start"; "GroupName" = "cloudbase_init"; "AsBoolean" = $true; "DefaultValue" = $false;
+          "Description" = "If set, the Cloudbase-Init service startup type will be set to delayed-auto"},
         @{"Name" = "enable_custom_wallpaper"; "DefaultValue" = $true; "AsBoolean" = $true;
           "Description" = "If set to true, a custom wallpaper will be set according to the values of configuration options
                            wallpaper_path and wallpaper_solid_color"},


### PR DESCRIPTION
Added option to set cloudbase-init service to auto-delayed start.

```ini
[cloudbase_init]
cloudbase_init_delayed_start=False
```
Sometimes we need cloudbase-init service to be set to auto delayed
start, to make sure that all the Windows services are up and running
when cloudbase-init runs. This scenario might fix the problems with
NETLBFO bond, when cloudbase-init tries to create the bonds, but the
bonding networking services are not ready and silent failures can occur.

Fixes:
https://github.com/cloudbase/windows-openstack-imaging-tools/issues/341