### PR TITLE
Fixed multiple iso mount points for VirtIO

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -826,6 +826,10 @@ function Add-VirtIODriversFromISO {
         [string]$isoPath
     )
     Write-Log "Adding Virtual IO Drivers from ISO: $isoPath..."
+    $isoPathBak = $isoPath + (Get-Random) + ".iso"
+    Copy-Item $isoPath $isoPathBak -Force
+    Write-Log "Using backed up ISO for safe dismount."
+    $isoPath = $isoPathBak
     $v = [WIMInterop.VirtualDisk]::OpenVirtualDisk($isoPath)
     try {
         if (Is-IsoFile $isoPath) {
@@ -857,6 +861,7 @@ function Add-VirtIODriversFromISO {
             $v.DetachVirtualDisk()
             $v.Close()
         }
+        Remove-Item -Force $isoPath
     }
     Write-Log "ISO Virtual Drivers have been adeed."
 }


### PR DESCRIPTION
If multiple images are generated using the same VirtIO ISO,
there is a chance that the imaging tool will dismount the VirtIO
ISO at a path in use, which triggers an error to apply the
drivers.

Copying the ISO to a backup file and mounting that ISO will
fix the issue.

This fix might be time / space consuming, but it is the only way
to make sure that the proper ISO is unmounted,
as there is no way to get the mount
point from the ISO file path itself, without making a persistance layer
logic to track which ISO file corresponds to which mount point and make
another persistence layer to track the mount points. Even if the mount
points and file paths are tracked, in highly used envs, there is a
probability that the mount points cannot be properly tracked due to
concurrency issues (when 2 ISOs are mounted at the +- epsilon time),
which is exactly what we want to avoid.