### PR TITLE
Officialize support Windows Server 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following versions of Windows images (both x86 / x64, if existent) to be gen
 * Windows Server 2008 / 2008 R2
 * Windows Server 2012 / 2012 R2
 * Windows Server 2016 
+* Windows Server 2019
 * Windows 7 / 8 / 8.1 / 10
 
 To generate Windows Nano Server 2016, please use the following repository:


### PR DESCRIPTION
Windows Server 2019 was supported from its initial release,
as it was an incremental upgrade for the Windows Server 2016 version.