### PR TITLE
Add QEMU Guest Agent checksum verification with SHA256

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -115,12 +115,16 @@ function Get-AvailableConfigOptions {
         @{"Name" = "install_qemu_ga"; "GroupName" = "custom";"DefaultValue" = "False";
           "Description" = "Installs QEMU guest agent services from the Fedora VirtIO website.
                            Defaults to 'False' (no installation will be performed).
-                           If set to 'True', the following MSI installer will be downloaded and installed:
+                           If set to 'True', by default, the following MSI installer will be downloaded and installed:
                              * for x86: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x86.msi
                              * for x64: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x64.msi
                            The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
                            Note: QEMU guest agent requires VirtIO drivers to be present on the image.
                           "},
+        @{"Name" = "url"; "GroupName" = "virtio_qemu_guest_agent";
+          "Description" = "Custom URL for QEMU Guest Agent MSI installer. Must be used together with 'checksum' parameter for SHA256 verification."},
+        @{"Name" = "checksum"; "GroupName" = "virtio_qemu_guest_agent";
+          "Description" = "SHA256 checksum of the QEMU Guest Agent MSI installer. Must be used together with 'url' parameter."},
         @{"Name" = "drivers_path"; "GroupName" = "drivers";
           "Description" = "The location where additional drivers that are needed for the image are located."},
         @{"Name" = "install_updates"; "GroupName" = "updates"; "DefaultValue" = $false; "AsBoolean" = $true;

--- a/Examples/windows-image-config-example.ini
+++ b/Examples/windows-image-config-example.ini
@@ -142,6 +142,19 @@ drivers_path=""
 # The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
 # Note: QEMU guest agent requires VirtIO drivers to be present on the image.
 install_qemu_ga=False
+
+[virtio_qemu_guest_agent]
+# Custom URL for QEMU Guest Agent MSI installer.
+# Must be used together with 'checksum' parameter for SHA256 verification.
+# Example: url=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi
+url=
+# SHA256 checksum of the QEMU Guest Agent MSI installer.
+# Must be used together with 'url' parameter.
+# To get the checksum on Windows: Get-FileHash -Path "qemu-ga-x64.msi" -Algorithm SHA256
+# To get the checksum on Linux/macOS: sha256sum qemu-ga-x64.msi
+checksum=
+
+[custom]
 # Set a custom timezone for the Windows image.
 time_zone=""
 # Set custom ntp servers(space separated) for the Windows image

--- a/README.md
+++ b/README.md
@@ -94,6 +94,62 @@ the resulting VHDX is shrinked to a minimum size and converted to the required f
 You can find a PowerShell example to generate a raw OpenStack Ironic image that also works on KVM<br/>
 in `Examples/create-windows-online-cloud-image.ps1`
 
+## QEMU Guest Agent Configuration
+
+### Overview
+
+The QEMU Guest Agent installation supports optional SHA256 checksum verification for enhanced security, while maintaining full backward compatibility.
+
+### Configuration Options
+
+#### 1. Default Installation (Simple)
+
+```ini
+[custom]
+install_qemu_ga=True
+```
+
+Uses the default version from the VirtIO archive.
+
+#### 2. Custom URL (Legacy)
+
+```ini
+[custom]
+install_qemu_ga=https://example.com/custom-qemu-ga.msi
+```
+
+#### 3. Secure Installation with Checksum (Recommended)
+
+```ini
+[custom]
+install_qemu_ga=True
+
+[virtio_qemu_guest_agent]
+url=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi
+checksum=<SHA256_CHECKSUM>
+```
+
+**Important**: Both `url` and `checksum` must be specified together to enable checksum verification.
+
+### Getting the SHA256 Checksum
+
+**Windows (PowerShell)**:
+```powershell
+Get-FileHash -Path "qemu-ga-x64.msi" -Algorithm SHA256
+```
+
+**Linux/macOS**:
+```bash
+sha256sum qemu-ga-x64.msi
+```
+
+### Benefits of Checksum Verification
+
+- **Security**: Verifies downloaded file integrity
+- **Control**: Know exactly which version will be installed
+- **Protection**: Prevents man-in-the-middle attacks
+- **Compliance**: Facilitates security audits
+
 ## Frequently Asked Questions (FAQ)
 
 ### The image generation never stops


### PR DESCRIPTION
This PR adds SHA256 checksum verification for QEMU Guest Agent installation, enhancing security while maintaining full backward compatibility.
## New Features
- New `[virtio_qemu_guest_agent]` configuration section with `url` and `checksum` parameters
- SHA256 checksum verification in `Download-QemuGuestAgent` function
- Priority-based configuration system
## Configuration Example
```ini
[custom]
install_qemu_ga=True
[virtio_qemu_guest_agent]
url=[https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi)
checksum=<SHA256_CHECKSUM>
```

## Benefits
Security: Verifies downloaded file integrity
Control: Know exactly which version will be installed
Protection: Prevents man-in-the-middle attacks
Compliance: Facilitates security audits
Backward Compatibility
All existing configurations continue to work without modification:

- install_qemu_ga=True → Uses default URL
- install_qemu_ga=<URL> → Uses custom URL without checksum


## Files Modified
Config.psm1
WinImageBuilder.psm1
Examples/windows-image-config-example.ini
README.md