### PR TITLE
Add QEMU Guest Agent installation from VirtIO ISO

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -115,12 +115,16 @@ function Get-AvailableConfigOptions {
         @{"Name" = "install_qemu_ga"; "GroupName" = "custom";"DefaultValue" = "False";
           "Description" = "Installs QEMU guest agent services from the Fedora VirtIO website.
                            Defaults to 'False' (no installation will be performed).
-                           If set to 'True', the following MSI installer will be downloaded and installed:
+                           If set to 'True', by default, the following MSI installer will be downloaded and installed:
                              * for x86: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x86.msi
                              * for x64: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x64.msi
                            The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
                            Note: QEMU guest agent requires VirtIO drivers to be present on the image.
                           "},
+        @{"Name" = "url"; "GroupName" = "virtio_qemu_guest_agent";
+          "Description" = "Custom URL for QEMU Guest Agent MSI installer. Must be used together with 'checksum' parameter for SHA256 verification."},
+        @{"Name" = "checksum"; "GroupName" = "virtio_qemu_guest_agent";
+          "Description" = "SHA256 checksum of the QEMU Guest Agent MSI installer. Must be used together with 'url' parameter."},
         @{"Name" = "drivers_path"; "GroupName" = "drivers";
           "Description" = "The location where additional drivers that are needed for the image are located."},
         @{"Name" = "install_updates"; "GroupName" = "updates"; "DefaultValue" = $false; "AsBoolean" = $true;

--- a/Config.psm1
+++ b/Config.psm1
@@ -121,6 +121,12 @@ function Get-AvailableConfigOptions {
                            The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
                            Note: QEMU guest agent requires VirtIO drivers to be present on the image.
                           "},
+        @{"Name" = "source"; "GroupName" = "virtio_qemu_guest_agent"; "DefaultValue" = "web";
+          "Description" = "Source for QEMU Guest Agent installation. Options:
+                           'iso' - Extract from VirtIO ISO (requires virtio_iso_path to be set),
+                           'web' - Download from Internet (default behavior),
+                           'auto' - Try ISO first, fallback to web if extraction fails.
+                           Default: 'web'"},
         @{"Name" = "url"; "GroupName" = "virtio_qemu_guest_agent";
           "Description" = "Custom URL for QEMU Guest Agent MSI installer. Must be used together with 'checksum' parameter for SHA256 verification."},
         @{"Name" = "checksum"; "GroupName" = "virtio_qemu_guest_agent";

--- a/Examples/windows-image-config-example.ini
+++ b/Examples/windows-image-config-example.ini
@@ -144,6 +144,12 @@ drivers_path=""
 install_qemu_ga=False
 
 [virtio_qemu_guest_agent]
+# Source for QEMU Guest Agent installation. Options:
+# - 'iso': Extract from VirtIO ISO (requires virtio_iso_path to be set)
+# - 'web': Download from Internet (default behavior)
+# - 'auto': Try ISO first, fallback to web if extraction fails
+# Default: 'web'
+source=web
 # Custom URL for QEMU Guest Agent MSI installer.
 # Must be used together with 'checksum' parameter for SHA256 verification.
 # Example: url=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi

--- a/Examples/windows-image-config-example.ini
+++ b/Examples/windows-image-config-example.ini
@@ -142,6 +142,19 @@ drivers_path=""
 # The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
 # Note: QEMU guest agent requires VirtIO drivers to be present on the image.
 install_qemu_ga=False
+
+[virtio_qemu_guest_agent]
+# Custom URL for QEMU Guest Agent MSI installer.
+# Must be used together with 'checksum' parameter for SHA256 verification.
+# Example: url=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi
+url=
+# SHA256 checksum of the QEMU Guest Agent MSI installer.
+# Must be used together with 'url' parameter.
+# To get the checksum on Windows: Get-FileHash -Path "qemu-ga-x64.msi" -Algorithm SHA256
+# To get the checksum on Linux/macOS: sha256sum qemu-ga-x64.msi
+checksum=
+
+[custom]
 # Set a custom timezone for the Windows image.
 time_zone=""
 # Set custom ntp servers(space separated) for the Windows image

--- a/README.md
+++ b/README.md
@@ -94,6 +94,62 @@ the resulting VHDX is shrinked to a minimum size and converted to the required f
 You can find a PowerShell example to generate a raw OpenStack Ironic image that also works on KVM<br/>
 in `Examples/create-windows-online-cloud-image.ps1`
 
+## QEMU Guest Agent Configuration
+
+### Overview
+
+The QEMU Guest Agent installation supports optional SHA256 checksum verification for enhanced security, while maintaining full backward compatibility.
+
+### Configuration Options
+
+#### 1. Default Installation (Simple)
+
+```ini
+[custom]
+install_qemu_ga=True
+```
+
+Uses the default version from the VirtIO archive.
+
+#### 2. Custom URL (Legacy)
+
+```ini
+[custom]
+install_qemu_ga=https://example.com/custom-qemu-ga.msi
+```
+
+#### 3. Secure Installation with Checksum (Recommended)
+
+```ini
+[custom]
+install_qemu_ga=True
+
+[virtio_qemu_guest_agent]
+url=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-VERSION/qemu-ga-x64.msi
+checksum=<SHA256_CHECKSUM>
+```
+
+**Important**: Both `url` and `checksum` must be specified together to enable checksum verification.
+
+### Getting the SHA256 Checksum
+
+**Windows (PowerShell)**:
+```powershell
+Get-FileHash -Path "qemu-ga-x64.msi" -Algorithm SHA256
+```
+
+**Linux/macOS**:
+```bash
+sha256sum qemu-ga-x64.msi
+```
+
+### Benefits of Checksum Verification
+
+- **Security**: Verifies downloaded file integrity
+- **Control**: Know exactly which version will be installed
+- **Protection**: Prevents man-in-the-middle attacks
+- **Compliance**: Facilitates security audits
+
 ## Frequently Asked Questions (FAQ)
 
 ### The image generation never stops

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -563,6 +563,129 @@ function Download-CloudbaseInit {
     }
 }
 
+function Copy-QemuGuestAgentFromISO {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$IsoPath,
+        [Parameter(Mandatory=$true)]
+        [string]$ResourcesDir,
+        [Parameter(Mandatory=$true)]
+        [string]$OsArch
+    )
+
+    Write-Log "Extracting QEMU Guest Agent from VirtIO ISO: $IsoPath..."
+    
+    # Map architecture to ISO file naming convention
+    $arch = "i386"
+    $archAlt = "x86"
+    if ($OsArch -eq "AMD64") {
+        $arch = "x86_64"
+        $archAlt = "x64"
+    }
+    
+    $isoPathBak = $IsoPath + (Get-Random) + ".iso"
+    Copy-Item $IsoPath $isoPathBak -Force
+    Write-Log "Using backed up ISO for safe dismount."
+    $IsoPath = $isoPathBak
+    
+    $v = [WIMInterop.VirtualDisk]::OpenVirtualDisk($IsoPath)
+    try {
+        if (Is-IsoFile $IsoPath) {
+            $v.AttachVirtualDisk()
+            Get-PSDrive | Out-Null
+            $devicePath = $v.GetVirtualDiskPhysicalPath()
+            $isoDriveLetter = Execute-Retry {
+                $res = (Get-DiskImage -DevicePath $devicePath | Get-Volume).DriveLetter
+                if (!$res) {
+                    throw "Failed to mount ISO ${IsoPath}"
+                }
+                return $res
+            }
+            $isoDriveLetter += ":"
+            
+            Write-Log "Searching for QEMU Guest Agent in VirtIO ISO at ${isoDriveLetter}..."
+            
+            # List root directory content for debugging
+            Write-Log "Listing ISO root directory content:"
+            try {
+                $rootItems = Get-ChildItem -Path "${isoDriveLetter}\" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+                Write-Log "Root items: $($rootItems -join ', ')"
+            } catch {
+                Write-Log "Could not list root directory: $_"
+            }
+            
+            # Check if guest-agent directory exists and list its content
+            if (Test-Path "${isoDriveLetter}\guest-agent") {
+                Write-Log "guest-agent directory found, listing content:"
+                try {
+                    $gaItems = Get-ChildItem -Path "${isoDriveLetter}\guest-agent" -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
+                    foreach ($item in $gaItems) {
+                        Write-Log "  - $item"
+                    }
+                } catch {
+                    Write-Log "Could not list guest-agent directory: $_"
+                }
+            }
+            
+            # Try multiple possible paths with both naming conventions
+            $possiblePaths = @(
+                "${isoDriveLetter}\guest-agent\qemu-ga-${arch}.msi",
+                "${isoDriveLetter}\guest-agent\qemu-ga-${archAlt}.msi",
+                "${isoDriveLetter}\guest-agent\qemu-ga-${arch}\qemu-ga-${arch}.msi",
+                "${isoDriveLetter}\guest-agent\${arch}\qemu-ga-${arch}.msi",
+                "${isoDriveLetter}\qemu-ga\qemu-ga-${arch}.msi",
+                "${isoDriveLetter}\qemu-ga-${arch}.msi",
+                "${isoDriveLetter}\${arch}\qemu-ga-${arch}.msi"
+            )
+            
+            # Also try to find any MSI file containing "qemu-ga" and the architecture
+            Write-Log "Searching for QEMU Guest Agent MSI files..."
+            $qemuGaMsiPath = $null
+            foreach ($path in $possiblePaths) {
+                Write-Log "Checking path: $path"
+                if (Test-Path $path) {
+                    $qemuGaMsiPath = $path
+                    Write-Log "Found QEMU Guest Agent at: $path"
+                    break
+                }
+            }
+            
+            # If not found in standard paths, try to search recursively
+            if (!$qemuGaMsiPath) {
+                Write-Log "Not found in standard paths, searching recursively..."
+                try {
+                    $foundFiles = Get-ChildItem -Path "${isoDriveLetter}\" -Recurse -Filter "*qemu-ga*${arch}*.msi" -ErrorAction SilentlyContinue
+                    if ($foundFiles) {
+                        $qemuGaMsiPath = $foundFiles[0].FullName
+                        Write-Log "Found QEMU Guest Agent via recursive search at: $qemuGaMsiPath"
+                    }
+                } catch {
+                    Write-Log "Recursive search failed: $_"
+                }
+            }
+            
+            if (!$qemuGaMsiPath) {
+                throw "QEMU Guest Agent MSI not found in VirtIO ISO for architecture: $arch. Searched paths: $($possiblePaths -join ', '). Please check the ISO structure and update the search paths if needed."
+            }
+            
+            $dst = Join-Path $ResourcesDir "qemu-ga.msi"
+            Copy-Item -Path $qemuGaMsiPath -Destination $dst -Force
+            Write-Log "QEMU Guest Agent copied successfully to: $dst"
+            
+        } else {
+            throw "The $IsoPath is not a valid ISO path."
+        }
+    } catch {
+        throw $_
+    } finally {
+        if ($v) {
+            $v.DetachVirtualDisk()
+            $v.Close()
+        }
+        Remove-Item -Force $IsoPath
+    }
+}
+
 function Download-QemuGuestAgent {
     Param(
         [Parameter(Mandatory=$true)]
@@ -574,7 +697,11 @@ function Download-QemuGuestAgent {
         [Parameter(Mandatory=$false)]
         [string]$CustomUrl,
         [Parameter(Mandatory=$false)]
-        [string]$Checksum
+        [string]$Checksum,
+        [Parameter(Mandatory=$false)]
+        [string]$Source = "web",
+        [Parameter(Mandatory=$false)]
+        [string]$VirtioIsoPath
     )
 
     $useCustomConfig = $false
@@ -598,22 +725,54 @@ function Download-QemuGuestAgent {
         Write-Log "SHA256 checksum verification successful"
     }
     
-    # Priority 2: Use legacy behavior (backward compatibility)
+    # Priority 2: Source-based installation (iso/web/auto)
     if (!$useCustomConfig) {
-        $QemuGuestAgentUrl = $QemuGuestAgentConfig
-        if ($QemuGuestAgentConfig -eq 'True') {
-            $arch = "x86"
-            if ($OsArch -eq "AMD64") {
-                $arch = "x64"
+        $useSourceConfig = $false
+        
+        # Check if source is set to 'iso' or 'auto'
+        if ($Source -eq "iso" -or $Source -eq "auto") {
+            if ($VirtioIsoPath -and (Test-Path $VirtioIsoPath)) {
+                Write-Log "Source set to '$Source': Attempting to extract QEMU Guest Agent from VirtIO ISO"
+                try {
+                    Copy-QemuGuestAgentFromISO -IsoPath $VirtioIsoPath -ResourcesDir $ResourcesDir -OsArch $OsArch
+                    $useSourceConfig = $true
+                } catch {
+                    if ($Source -eq "iso") {
+                        # If source is explicitly 'iso', fail with error
+                        throw "Failed to extract QEMU Guest Agent from VirtIO ISO: $_"
+                    } else {
+                        # If source is 'auto', log the error and fall back to web download
+                        Write-Log "Failed to extract QEMU Guest Agent from VirtIO ISO: $_"
+                        Write-Log "Falling back to web download..."
+                    }
+                }
+            } else {
+                if ($Source -eq "iso") {
+                    throw "Source is set to 'iso' but VirtIO ISO path is not provided or does not exist: $VirtioIsoPath"
+                } else {
+                    Write-Log "VirtIO ISO not available, falling back to web download"
+                }
             }
-            $QemuGuestAgentUrl = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads" + `
-                                 "/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-{0}.msi" -f $arch
         }
+        
+        # Priority 3: Use web download (legacy behavior or fallback from 'auto')
+        if (!$useSourceConfig) {
+            Write-Log "Using web download for QEMU Guest Agent"
+            $QemuGuestAgentUrl = $QemuGuestAgentConfig
+            if ($QemuGuestAgentConfig -eq 'True') {
+                $arch = "x86"
+                if ($OsArch -eq "AMD64") {
+                    $arch = "x64"
+                }
+                $QemuGuestAgentUrl = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads" + `
+                                     "/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-{0}.msi" -f $arch
+            }
 
-        Write-Log "Downloading QEMU guest agent installer from ${QemuGuestAgentUrl} ..."
-        $dst = Join-Path $ResourcesDir "qemu-ga.msi"
-        Execute-Retry {
-            (New-Object System.Net.WebClient).DownloadFile($QemuGuestAgentUrl, $dst)
+            Write-Log "Downloading QEMU guest agent installer from ${QemuGuestAgentUrl} ..."
+            $dst = Join-Path $ResourcesDir "qemu-ga.msi"
+            Execute-Retry {
+                (New-Object System.Net.WebClient).DownloadFile($QemuGuestAgentUrl, $dst)
+            }
         }
     }
     
@@ -1742,7 +1901,8 @@ function New-WindowsCloudImage {
             if ($windowsImageConfig.install_qemu_ga -and $windowsImageConfig.install_qemu_ga -ne 'False') {
                 Download-QemuGuestAgent -QemuGuestAgentConfig $windowsImageConfig.install_qemu_ga `
                     -ResourcesDir $resourcesDir -OsArch ([string]$image.ImageArchitecture) `
-                    -CustomUrl $windowsImageConfig.url -Checksum $windowsImageConfig.checksum
+                    -CustomUrl $windowsImageConfig.url -Checksum $windowsImageConfig.checksum `
+                    -Source $windowsImageConfig.source -VirtioIsoPath $windowsImageConfig.virtio_iso_path
             }
             Download-CloudbaseInit -resourcesDir $resourcesDir -osArch ([string]$image.ImageArchitecture) `
                                    -BetaRelease:$windowsImageConfig.beta_release -MsiPath $windowsImageConfig.msi_path `
@@ -1924,7 +2084,8 @@ function New-WindowsFromGoldenImage {
         if ($windowsImageConfig.install_qemu_ga -and $windowsImageConfig.install_qemu_ga -ne 'False') {
             Download-QemuGuestAgent -QemuGuestAgentConfig $windowsImageConfig.install_qemu_ga `
                 -ResourcesDir $resourcesDir -OsArch $imageInfo.imageArchitecture `
-                -CustomUrl $windowsImageConfig.url -Checksum $windowsImageConfig.checksum
+                -CustomUrl $windowsImageConfig.url -Checksum $windowsImageConfig.checksum `
+                -Source $windowsImageConfig.source -VirtioIsoPath $windowsImageConfig.virtio_iso_path
         }
         Download-CloudbaseInit -resourcesDir $resourcesDir -osArch $imageInfo.imageArchitecture `
                                -BetaRelease:$windowsImageConfig.beta_release -MsiPath $windowsImageConfig.msi_path `


### PR DESCRIPTION
This PR adds the ability to install the QEMU Guest Agent directly from a VirtIO ISO file instead of always downloading from the internet.
 
**⚠️ Note**: This PR depends on #413  (QEMU GA checksum verification) and should be merged after it.
 
## New Features
- New `source` parameter with three options:
  - `web`: Download from internet (default, backward compatible)
  - `iso`: Extract from VirtIO ISO only
  - `auto`: Try ISO first, fallback to web
- New `Copy-QemuGuestAgentFromISO` function for ISO extraction
- Automatic architecture detection (x86_64/i386)
- Comprehensive search with fallback paths and recursive search
 
## Configuration Examples
 
### Offline Mode
```ini
[drivers]
virtio_iso_path=/path/to/virtio-win.iso
 
[custom]
install_qemu_ga=True
 
[virtio_qemu_guest_agent]
source=iso
Automatic Mode (Recommended)
ini
[drivers]
virtio_iso_path=/path/to/virtio-win.iso
[custom]
install_qemu_ga=True
[virtio_qemu_guest_agent]
source=auto
```

## Benefits
- Offline environments: Support for air-gapped systems
- Faster builds: No network download required
- Version consistency: Match guest agent with VirtIO drivers version
- Bandwidth savings: Reuse ISO for multiple image builds
- Flexibility: auto mode works both online and offline

## Technical Details
- Mounts ISO using Windows VirtualDisk API
- Searches multiple possible paths for the MSI file
- Includes recursive search as fallback
- Safe ISO dismount with cleanup
- Backward Compatibility
- All existing configurations continue to work without modification. The default source=web maintains current behavior.

## Files Modified
Config.psm1
WinImageBuilder.psm1
Examples/windows-image-config-example.ini
README.md
