### PR TITLE
resolve VirtIO osVersion once in Get-VirtIODrivers

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -768,24 +768,28 @@ function Get-VirtIODrivers {
     )
 
     Write-Log "Getting Virtual IO Drivers: $BasePath..."
-    $driverPaths = @()
-    foreach ($driver in $VirtioDrivers) {
-        foreach ($osVersion in $VirtIODriverMappings.Keys) {
-            $map = $VirtIODriverMappings[$osVersion]
+    $osVersion = $null
+    foreach ($entry in $VirtIODriverMappings.Keys) {
+            $map = $VirtIODriverMappings[$entry]
             $minBuildNumber = $map[0]
             $maxBuildNumber = $map[1]
             $isServerVersion = $map[2]
-            if (!(($BuildNumber -ge $minBuildNumber -and $BuildNumber -le $maxBuildNumber) `
-                -and ($isServerVersion -eq $isServer))) {
-              continue
+            if (($BuildNumber -ge $minBuildNumber -and $BuildNumber -le $maxBuildNumber) `
+                -and ($isServerVersion -eq $isServer)) {
+                $osVersion = $entry
+                break
             }
+    }
+
+    $driverPaths = @()
+    if ($osVersion) {
+        foreach ($driver in $VirtioDrivers) {
             $driverPath = "{0}\{1}\{2}\{3}" -f @($basePath,
                                                  $driver,
                                                  $osVersion,
                                                  $architecture)
             if (Test-Path $driverPath) {
                 $driverPaths += $driverPath
-                break
             }
         }
     }


### PR DESCRIPTION
The current implementation resolves the matching osVersion inside the per-driver loop, which means we iterate over the OS mapping table for every driver even though the mapping does not depend on the driver, which creates unnecessary iterations.
This change computes the osVersion once up front and then uses that resolved version to build and validate the driver paths, keeping the same behavior.