### PR TITLE
Make source ISO detection case-insensitive

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -1639,7 +1639,7 @@ function New-WindowsCloudImage {
     try {
         $windowsImageConfig = Get-WindowsImageConfig -ConfigFilePath $ConfigFilePath
         $mountedWindowsIso = $null
-        if ($windowsImageConfig.wim_file_path.EndsWith('.iso')) {
+        if ($windowsImageConfig.wim_file_path.toLower().EndsWith('.iso')) {
             $windowsImageConfig.wim_file_path = Get-Command $windowsImageConfig.wim_file_path `
                 -ErrorAction Ignore | Select-Object -ExpandProperty Source
             if($windowsImageConfig.wim_file_path -eq $null){


### PR DESCRIPTION
Currently, when wim_file_path points to an ISO, the tool detects the .iso extension, mounts the image automatically, and uses the WIM from the mounted media. This detection is currently case-sensitive, so paths ending in .ISO are not recognized.
This PR updates the extension check to be case-insensitive.