### PR TITLE
Fix extra_capabilities not being split and trim comma-separated lists

### DIFF
--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -249,3 +249,33 @@ Describe "Test New-WindowsOnlineImage" {
 
     Remove-Item -Force -ErrorAction SilentlyContinue "${fakeConfigPath}.offline"
 }
+
+Describe "Test ConvertFrom-CommaSeparatedString" {
+    InModuleScope $moduleName {
+        It "splits comma separated values into separate entries" {
+            $result = @(ConvertFrom-CommaSeparatedString "OpenSSH.Server,OpenSSH.Client")
+            $result.Count | Should -Be 2
+            $result[0] | Should -Be "OpenSSH.Server"
+            $result[1] | Should -Be "OpenSSH.Client"
+        }
+        It "trims whitespace around each entry" {
+            $result = @(ConvertFrom-CommaSeparatedString "Microsoft-Hyper-V, Microsoft-Hyper-V-Management-Clients")
+            $result[0] | Should -Be "Microsoft-Hyper-V"
+            $result[1] | Should -Be "Microsoft-Hyper-V-Management-Clients"
+        }
+        It "drops empty entries produced by a trailing comma" {
+            $result = @(ConvertFrom-CommaSeparatedString "OpenSSH.Server,")
+            $result.Count | Should -Be 1
+            $result[0] | Should -Be "OpenSSH.Server"
+        }
+        It "returns an empty array for an empty value" {
+            $result = @(ConvertFrom-CommaSeparatedString "")
+            $result.Count | Should -Be 0
+        }
+        It "returns a single entry for a value without commas" {
+            $result = @(ConvertFrom-CommaSeparatedString "OpenSSH.Server")
+            $result.Count | Should -Be 1
+            $result[0] | Should -Be "OpenSSH.Server"
+        }
+    }
+}

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -668,6 +668,19 @@ function Add-PackageToImage {
     }
 }
 
+function ConvertFrom-CommaSeparatedString {
+    # Splits a comma separated config value into a clean array, trimming whitespace
+    # around each entry and dropping empty entries (e.g. from a trailing comma).
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Value
+    )
+    if (!$Value) {
+        return @()
+    }
+    return @($Value.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+}
+
 function Enable-FeaturesInImage {
     Param(
         [Parameter(Mandatory=$true)]
@@ -1737,15 +1750,15 @@ function New-WindowsCloudImage {
                     -driversBasePath $windowsImageConfig.virtio_base_path
             }
             if ($windowsImageConfig.extra_features) {
-                Enable-FeaturesInImage $winImagePath $windowsImageConfig.extra_features.split(",")
+                Enable-FeaturesInImage $winImagePath (ConvertFrom-CommaSeparatedString $windowsImageConfig.extra_features)
             }
             if ($windowsImageConfig.extra_packages) {
-                foreach ($package in $windowsImageConfig.extra_packages.split(",")) {
+                foreach ($package in (ConvertFrom-CommaSeparatedString $windowsImageConfig.extra_packages)) {
                     Add-PackageToImage $winImagePath $package -ignoreErrors $windowsImageConfig.extra_packages_ignore_errors
                 }
             }
             if ($windowsImageConfig.extra_capabilities) {
-                Add-CapabilitiesToImage $winImagePath $windowsImageConfig.extra_capabilities
+                Add-CapabilitiesToImage $winImagePath (ConvertFrom-CommaSeparatedString $windowsImageConfig.extra_capabilities)
             }
             if ($windowsImageConfig.clean_updates_offline) {
                 Clean-WindowsUpdates $winImagePath -PurgeUpdates $windowsImageConfig.purge_updates


### PR DESCRIPTION
extra_capabilities was passed to Add-CapabilitiesToImage as a single raw string instead of an array, so DISM received one bogus /CapabilityName:"A,B" argument and failed (e.g. OpenSSH.Server,OpenSSH.Client on Windows Server 2025).

Add a ConvertFrom-CommaSeparatedString helper that splits on commas, trims whitespace around each entry and drops empty entries, and use it for extra_features, extra_packages and extra_capabilities. This also fixes whitespace-padded values (e.g. "A, B") that previously broke DISM, and tolerates trailing commas.

Add unit tests for the new helper.

Closes: #422